### PR TITLE
fix: added SafeArea top for iOS & removed unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "@rescript/core": "^1.3.0",
     "@sentry/react-native": "^5.9.1",
     "react-native-code-push": "^8.1.0",
-    "react-native-hyperswitch-kount": "^0.1.0",
-    "react-native-hyperswitch-paypal": "^0.1.0",
     "react-native-hyperswitch-scancard": "^0.2.0",
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-klarna-inapp-sdk": "2.1.13",

--- a/src/components/common/CustomView.res
+++ b/src/components/common/CustomView.res
@@ -56,6 +56,7 @@ let make = (
         ~justifyContent=#center,
         (),
       )}>
+      <SafeAreaView />
       {children}
     </View>
     // </TouchableWithoutFeedback>


### PR DESCRIPTION
Added SafeAreaView to payment sheet top to avoid safe area interference on top for iOS devices

Before
<img src="https://github.com/juspay/hyperswitch-client-core/assets/128193838/3ede191e-aea5-49c8-b20a-9e87762834ae.png" width=20% height=20%>
After
<img src="https://github.com/juspay/hyperswitch-client-core/assets/128193838/19674f51-f88a-416d-bc31-f724b65587d8.png" width=20% height=20%>

also removed unused dependencies 
- Kount
- Paypal



