### PR TITLE
fix: animation fix on payment sheet

### DIFF
--- a/src/components/common/CustomTabView.res
+++ b/src/components/common/CustomTabView.res
@@ -50,23 +50,11 @@ let make = (
   let dimensions = Dimensions.useWindowDimensions()
   let (indexInFocus, setIndexInFocus) = React.useState(_ => 0)
   let setIndexInFocus = React.useCallback1(ind => setIndexInFocus(_ => ind), [setIndexInFocus])
-  let (heightPosition, _) = React.useState(_ => Animated.Value.create(0.))
+  let (height, setHeight) = React.useState(_ => 0.)
 
   let setDynamicHeight = height => {
-    Animated.timing(
-      heightPosition,
-      Animated.Value.Timing.config(
-        ~toValue={
-          height->Animated.Value.Timing.fromRawValue
-        },
-        ~isInteraction=true,
-        ~useNativeDriver=false,
-        ~delay=0.,
-        ~duration=130.,
-        ~easing=Easing.linear,
-        (),
-      ),
-    )->Animated.start()
+    setHeight(_ => height)
+    ()
   }
 
   let data = React.useMemo1(() => {
@@ -102,12 +90,12 @@ let make = (
       | None => true
       }
 
-  <Animated.View
+  <View
     style={viewStyle(
       ~minHeight=115.->dp,
       ~width=100.->pct,
       ~overflow=#hidden,
-      ~height=heightPosition->Animated.StyleProp.size,
+      ~height=height->dp,
       (),
     )}>
     {switch data->Array.length {
@@ -149,5 +137,5 @@ let make = (
         // pagerStyle={viewStyle(~height={heightPosition->Animated.StyleProp.size}, ())}
       />
     }}
-  </Animated.View>
+  </View>
 }

--- a/src/components/common/ErrorText.res
+++ b/src/components/common/ErrorText.res
@@ -2,19 +2,18 @@ open ReactNative
 open Style
 
 @react.component
-let make = (~text) => {
+let make = (~text=None) => {
   let {errorTextInputColor} = ThemebasedStyle.useThemeBasedStyle()
   let fontFamily = FontFamily.useCustomFontFamily()
 
   switch text {
-  | "" => React.null
-  | val =>
-    <>
-      <Space height=4. />
-      <Text style={textStyle(~color={errorTextInputColor}, ~fontFamily, ~fontSize=12., ())}>
-        {val->React.string}
-      </Text>
-      <Space />
-    </>
+  | None => React.null
+  | Some(val) => val == ""
+      ? React.null
+      : <>
+          <Text style={textStyle(~color={errorTextInputColor}, ~fontFamily, ~fontSize=12., ())}>
+            {val->React.string}
+          </Text>
+        </>
   }
 }

--- a/src/components/elements/ConfirmButton.res
+++ b/src/components/elements/ConfirmButton.res
@@ -9,28 +9,31 @@ let make = (
   ~hasSomeFields=?,
   ~paymentMethod: string,
   ~paymentExperience=?,
+  ~errorText=None,
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   let (allApiData, _) = React.useContext(AllApiDataContext.allApiDataContext)
   let localeObject = GetLocale.useGetLocalObj()
 
-  <View style={viewStyle(~marginHorizontal=18.->dp, ())}>
-    {loading
-      ? <>
-          <CustomLoader />
-          <Space />
-          <HyperSwitchBranding />
-        </>
-      : <ConfirmButtonAnimation
-          isAllValuesValid
-          handlePress
-          paymentMethod
-          ?hasSomeFields
-          ?paymentExperience
-          displayText={switch nativeProp.configuration.primaryButtonLabel {
-          | Some(str) => str
-          | None => allApiData.mandateType != NORMAL ? "Pay Now" : localeObject.payNowButton
-          }}
-        />}
-  </View>
+    <View style={viewStyle(~marginHorizontal=18.->dp, ())}>
+   {errorText->Belt.Option.isSome? <ErrorText text={errorText} />:React.null}
+      {loading
+        ? <>
+            <CustomLoader />
+            <Space />
+            <HyperSwitchBranding />
+          </>
+        : <ConfirmButtonAnimation
+            isAllValuesValid
+            handlePress
+            paymentMethod
+            ?hasSomeFields
+            ?paymentExperience
+            displayText={switch nativeProp.configuration.primaryButtonLabel {
+            | Some(str) => str
+            | None => allApiData.mandateType != NORMAL ? "Pay Now" : localeObject.payNowButton
+            }}
+          />}
+    </View>
+  
 }

--- a/src/components/elements/PaymentSheetUi.res
+++ b/src/components/elements/PaymentSheetUi.res
@@ -242,7 +242,7 @@ let make = (
       </View>
     </View>
     {!isCardNumberValid || !isExpireDateValid || !isCvvValid
-      ? <ErrorText text=localeObject.inValidCardErrorText />
+      ? <ErrorText text=Some(localeObject.inValidCardErrorText) />
       : React.null}
   </ErrorBoundary>
 }

--- a/src/pages/payment/Card.res
+++ b/src/pages/payment/Card.res
@@ -53,7 +53,7 @@ let make = (
   )> => [])
   // let (isAllBillingValuesValid, setIsAllBillingValuesValid) = React.useState(_ => false)
   let (isConfirmButtonValid, setIsConfirmButtonValid) = React.useState(_ => false)
-  let (error, setError) = React.useState(_ => "")
+  let (error, setError) = React.useState(_ => None)
 
   React.useEffect2(
     () => {
@@ -84,7 +84,7 @@ let make = (
       if !closeSDK {
         setLoading(FillingDetails)
         switch errorMessage.message {
-        | Some(message) => setError(_ => message)
+        | Some(message) => setError(_ => Some(message))
         | None => ()
         }
       }
@@ -136,16 +136,16 @@ let make = (
     processRequest(cardVal)
   }
 
-  React.useEffect2(() => {
+  React.useEffect3(() => {
     if isScreenFocus {
       setConfirmButtonDataRef(
         <ConfirmButton
-          loading=false isAllValuesValid=isConfirmButtonValid handlePress paymentMethod="CARD"
+          loading=false isAllValuesValid=isConfirmButtonValid handlePress paymentMethod="CARD" errorText=error
         />,
       )
     }
     None
-  }, (isConfirmButtonValid, isScreenFocus))
+  }, (isConfirmButtonValid, isScreenFocus,error))
   <View style={viewStyle(~marginHorizontal=18.->dp, ())}>
     <Space />
     <View>
@@ -194,7 +194,7 @@ let make = (
         // switch customer.id {
         // | Some(_) =>
         <>
-          <Space height=16. />
+          <Space height=8. />
           <ClickableTextElement
             disabled={false}
             initialIconName="checkboxClicked"
@@ -226,26 +226,6 @@ let make = (
       // <TextWrapper text=localeObject.countryOrRegion textType=Subheading />
       // <Space height=5. />
       // <BillingElement updateBilllingValues={updateBilllingValues} />
-
-      {PaymentUtils.showUseExisitingSavedCardsBtn(
-        ~isGuestCustomer=savedPaymentMethodsData.isGuestCustomer,
-        ~pmList=savedPaymentMethodsData.pmList,
-        ~mandateType=allApiData.mandateType,
-        ~displaySavedPaymentMethods=nativeProp.configuration.displaySavedPaymentMethods,
-      )
-        ? <>
-            <Space height=16. />
-            <ClickableTextElement
-              initialIconName="cardv1"
-              text=localeObject.useExisitingSavedCards
-              isSelected=true
-              setIsSelected={_ => ()}
-              textType={TextWrapper.TextActive}
-              fillIcon=true
-            />
-          </>
-        : React.null}
-      <Space />
       // {cardVal.required_field->Array.length != 0
       //   ? <DynamicFields
       //       setIsAllDynamicFieldValid
@@ -258,6 +238,6 @@ let make = (
       //     />
       //   : React.null}
     </View>
-    <ErrorText text=error />
+
   </View>
 }

--- a/src/pages/payment/NickNameElement.res
+++ b/src/pages/payment/NickNameElement.res
@@ -24,6 +24,7 @@ let make = (~nickname, ~setNickname, ~isNicknameSelected) => {
           borderLeftWidth=borderWidth
           borderRightWidth=borderWidth
         />
+        <Space height=5. />
       </>
     : React.null
 }

--- a/src/pages/payment/PaymentSheet.res
+++ b/src/pages/payment/PaymentSheet.res
@@ -1,3 +1,5 @@
+open ReactNative
+open Style
 @react.component
 let make = (~setConfirmButtonDataRef) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
@@ -5,6 +7,17 @@ let make = (~setConfirmButtonDataRef) => {
   //getting payment list data here
   let {tabArr, elementArr} = PMListModifier.useListModifier()()
   let (allApiData, _) = React.useContext(AllApiDataContext.allApiDataContext)
+
+  let (savedPaymentMethodsData, _) = React.useContext(
+    SavedPaymentMethodContext.savedPaymentMethodContext,
+  )
+  let savedPaymentMethodsData = switch savedPaymentMethodsData {
+  | Some(data) => data
+
+  | _ => SavedPaymentMethodContext.dafaultsavePMObj
+  }
+  let localeObject = GetLocale.useGetLocalObj()
+
   <>
     <WalletView
       loading={nativeProp.sdkState !== CardWidget && sessionData == Loading}
@@ -14,6 +27,26 @@ let make = (~setConfirmButtonDataRef) => {
     <CustomTabView
       hocComponentArr=tabArr loading={sessionData == Loading} setConfirmButtonDataRef
     />
-    // <Space/>
+    <View style={viewStyle(~paddingHorizontal=20.->dp, ())}>
+      {PaymentUtils.showUseExisitingSavedCardsBtn(
+        ~isGuestCustomer=savedPaymentMethodsData.isGuestCustomer,
+        ~pmList=savedPaymentMethodsData.pmList,
+        ~mandateType=allApiData.mandateType,
+        ~displaySavedPaymentMethods=nativeProp.configuration.displaySavedPaymentMethods,
+      )
+        ? <>
+            <Space height=16. />
+            <ClickableTextElement
+              initialIconName="cardv1"
+              text=localeObject.useExisitingSavedCards
+              isSelected=true
+              setIsSelected={_ => ()}
+              textType={TextWrapper.TextActive}
+              fillIcon=true
+            />
+            <Space height=25. />
+          </>
+        : React.null}
+    </View>
   </>
 }

--- a/src/pages/payment/Redirect.res
+++ b/src/pages/payment/Redirect.res
@@ -137,7 +137,7 @@ let make = (
     setSelectedBank(val)
   }
 
-  let (error, setError) = React.useState(_ => "")
+  let (error, setError) = React.useState(_ => None)
 
   let useHandleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
   let useRedirectHook = AllPaymentHooks.useRedirectHook()
@@ -161,7 +161,7 @@ let make = (
     if !closeSDK {
       setLoading(FillingDetails)
       switch errorMessage.message {
-      | Some(message) => setError(_ => message)
+      | Some(message) => setError(_ => Some(message))
       | None => ()
       }
     }
@@ -390,8 +390,8 @@ let make = (
       )
     | "User has canceled" =>
       setLoading(FillingDetails)
-      setError(_ => "Payment was Cancelled")
-    | err => setError(_ => err)
+      setError(_ => Some("Payment was Cancelled"))
+    | err => setError(_ => Some(err))
     }
   }
 
@@ -427,10 +427,10 @@ let make = (
       )
     | "Cancel" =>
       setLoading(FillingDetails)
-      setError(_ => "Payment was Cancelled")
+      setError(_ => Some("Payment was Cancelled"))
     | err =>
       setLoading(FillingDetails)
-      setError(_ => err)
+      setError(_ => Some(err))
     }
   }
 
@@ -442,13 +442,13 @@ let make = (
     ->Option.getOr("") {
     | "Cancelled" =>
       setLoading(FillingDetails)
-      setError(_ => "Cancelled")
+      setError(_ => Some("Cancelled"))
     | "Failed" =>
       setLoading(FillingDetails)
-      setError(_ => "Failed")
+      setError(_ =>Some( "Failed"))
     | "Error" =>
       setLoading(FillingDetails)
-      setError(_ => "Error")
+      setError(_ => Some("Error"))
     | _ =>
       let payment_data = var->Dict.get("payment_data")->Option.getOr(JSON.Encode.null)
 
@@ -459,7 +459,7 @@ let make = (
 
       if transaction_identifier->JSON.stringify == "Simulated Identifier" {
         setLoading(FillingDetails)
-        setError(_ => "Apple Pay is not supported in Simulated Environment")
+        setError(_ => Some("Apple Pay is not supported in Simulated Environment"))
       } else {
         let paymentData =
           [
@@ -608,7 +608,7 @@ let make = (
             sessionObject.payment_request_data == JSON.Encode.null
         ) {
           setLoading(FillingDetails)
-          setError(_ => "Waiting for Sessions API")
+          setError(_ => Some("Waiting for Sessions API"))
         } else {
           HyperModule.launchApplePay(
             [
@@ -688,16 +688,16 @@ let make = (
     )) || (fields.name == "klarna" && isKlarna)
   }, (isEmailValid, isNameValid, sessionData))
 
-  React.useEffect5(() => {
+  React.useEffect6(() => {
     if isScreenFocus {
       setConfirmButtonDataRef(
         <ConfirmButton
-          loading=false isAllValuesValid handlePress hasSomeFields paymentMethod ?paymentExperience
+          loading=false isAllValuesValid handlePress hasSomeFields paymentMethod ?paymentExperience errorText=error
         />,
       )
     }
     None
-  }, (isAllValuesValid, hasSomeFields, paymentMethod, paymentExperience, isScreenFocus))
+  }, (isAllValuesValid, hasSomeFields, paymentMethod, paymentExperience, isScreenFocus,error))
 
   <View style={viewStyle(~marginHorizontal=18.->dp, ())}>
     <Space />
@@ -796,11 +796,10 @@ let make = (
               </View>
             )
             ->React.array}
-            <ErrorText text=error />
             <Space />
             <RedirectionText />
           </>}
     </ErrorBoundary>
-    <Space height=18. />
+    <Space height=5. />
   </View>
 }

--- a/src/pages/payment/SavedPMListWithLoader.res
+++ b/src/pages/payment/SavedPMListWithLoader.res
@@ -61,7 +61,7 @@ let make = (
 
   savedPaymentMethordContextObj == Loading
     ? <LoadingPmList />
-    : <ScrollView style={viewStyle(~minHeight=200.->dp, ())}>
+    : <ScrollView style={viewStyle(~minHeight=0.->dp, ())}>
         {Some(listArr)
         ->Option.getOr([])
         ->Array.mapWithIndex((item, i) => {

--- a/src/pages/payment/SavedPaymentScreen.res
+++ b/src/pages/payment/SavedPaymentScreen.res
@@ -8,7 +8,7 @@ let make = (
   // let savedMandates = AllPaymentHooks.useGetSavedMandatesHook()
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
 
-  let (error, setError) = React.useState(_ => "")
+  let (error, setError) = React.useState(_ => None)
   let useHandleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
   let (allApiData, _) = React.useContext(AllApiDataContext.allApiDataContext)
   let useRedirectHook = AllPaymentHooks.useRedirectHook()
@@ -40,7 +40,7 @@ let make = (
       if !closeSDK {
         setLoading(FillingDetails)
         switch errorMessage.message {
-        | Some(message) => setError(_ => message)
+        | Some(message) => setError(_ => Some(message))
         | None => ()
         }
       }
@@ -122,7 +122,7 @@ let make = (
   //   None
   // }, [savedPaymentMethodsData])
 
-  React.useEffect4(() => {
+  React.useEffect5(() => {
     let selectedObj = savedPaymentMethordContextObj.selectedPaymentMethod->Option.getOr({
       walletName: NONE,
       token: Some(""),
@@ -140,6 +140,7 @@ let make = (
         handlePress
         hasSomeFields=false
         paymentMethod
+        errorText=error
       />,
     )
     None
@@ -148,6 +149,7 @@ let make = (
     allApiData,
     isAllDynamicFieldValid,
     dynamicFieldsJson,
+    error
   ))
 
   // React.useEffect1(() => {
@@ -177,7 +179,6 @@ let make = (
     <Space />
     <SavedPaymentScreenChild
       savedPaymentMethodsData={savedPaymentMethordContextObj.pmList->Option.getOr([])}
-      error
       setIsAllDynamicFieldValid
       setDynamicFieldsJson
     />

--- a/src/pages/payment/SavedPaymentScreenChild.res
+++ b/src/pages/payment/SavedPaymentScreenChild.res
@@ -4,7 +4,6 @@ open ReactNative.Style
 @react.component
 let make = (
   ~savedPaymentMethodsData,
-  ~error,
   ~setIsAllDynamicFieldValid,
   ~setDynamicFieldsJson,
 ) => {
@@ -51,8 +50,7 @@ let make = (
           fillIcon=false
         />
       </View>
-      <Space />
+      <Space height=25./>
     </View>
-    <ErrorText text=error />
   </View>
 }


### PR DESCRIPTION
### 🔧 FIXED
- **Animation on payment sheet**
   When the user switches back from `Payment method selection` page to `Saved payments page` there's no animation. This was fixed with addition of smooth `Linear-ease` animation.

-
| Fixed                                           | Screenshot (before fix)                                                                                                        |
|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
| Removed blank space below saved payment methods | <img src="https://github.com/juspay/hyperswitch-client-core/assets/76263821/03f236f5-7ce7-4f64-9370-85c7bdafa639" width=250 /> |


### ✨ ADDED
- `Use saved payment methods` option on all payment method pages (Klarna, WeChat Pay, Alipay, etc.)
<img src="https://github.com/juspay/hyperswitch-client-core/assets/76263821/487b54ca-bd88-49e5-b82f-6fbbf0e3aaa8" width=250 />


#

### 📸 SCREEN CAPTURES

| Before                                                                                                 | After (Fixed)                                                                                          |
|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
| https://github.com/juspay/hyperswitch-client-core/assets/76263821/1f9cd097-9da3-4fd1-823c-eddfd356c844 | https://github.com/juspay/hyperswitch-client-core/assets/76263821/e78ff6b7-4a35-4582-862f-6b79fba77c10 |

##### Final View
https://github.com/juspay/hyperswitch-client-core/assets/76263821/537b7671-743c-4c06-b712-1c7cb4d28aaa



