### PR TITLE
feat: added x-redirect-uri in headers

### DIFF
--- a/src/utility/logics/Utils.res
+++ b/src/utility/logics/Utils.res
@@ -138,14 +138,12 @@ let rec transformKeysSnakeToCamel = (json: JSON.t) => {
   ->JSON.Encode.object
 }
 
-let getHeader = (apiKey, appId) => {
+let getHeader = (apiKey, appId, ~redirectUri=?) => {
   [
-    ("Content-Type", "application/json"),
     ("api-key", apiKey),
     ("x-app-id", Js.String.replace(".hyperswitch://", "", appId->Option.getOr(""))),
+    ("x-redirect-uri", redirectUri->Option.getOr("")),
     // ("x-feature", "router-custom-be"),
-    ("x-merchant-domain", "rnweb.netlify.app"),
-    ("x-browser-name", "Safari"),
   ]->Dict.fromArray
 }
 


### PR DESCRIPTION
`x-redirect-uri`: This header property can be used for app to app redirection flows in iOS. The redirect-uri is expected to hold app-link for merchant's app.