### PR TITLE
fix: error on invalid ephemeral key

### DIFF
--- a/src/routes/PMMangementNavigatorRouter.res
+++ b/src/routes/PMMangementNavigatorRouter.res
@@ -31,7 +31,13 @@ let make = () => {
   }, [nativeProp])
 
   switch nativeProp.ephemeralKey {
-  | Some(_) => <PaymentMethodsManagement />
+  | Some(ephemeralKey) =>
+    ephemeralKey != ""
+      ? <PaymentMethodsManagement />
+      : {
+          showErrorOrWarning(ErrorUtils.errorWarning.invalidEphemeralKey, ())
+          React.null
+        }
   | None =>
     showErrorOrWarning(ErrorUtils.errorWarning.invalidEphemeralKey, ())
     React.null

--- a/src/utility/reusableCodeFromWeb/ErrorUtils.res
+++ b/src/utility/reusableCodeFromWeb/ErrorUtils.res
@@ -72,7 +72,7 @@ let errorWarning = {
     ),
   ),
   invalidEphemeralKey: INVALID_EK(
-    Error,
+    Warning,
     Static(
       "INTEGRATION ERROR: Ephemeral key not available.",
     ),


### PR DESCRIPTION
## FIXED:
Error pop-up in case of no `ephemeral key` passed while initializing `Payment Methods Management`.

## RECORDING:
https://github.com/user-attachments/assets/c16585cf-d270-4d35-bc27-fbbef10de72c

