### PR TITLE
fix: save new payment method flow

### DIFF
--- a/src/components/modules/HyperModule.res
+++ b/src/components/modules/HyperModule.res
@@ -9,6 +9,7 @@ type hyperModule = {
   exitWidget: (string, string) => unit,
   exitCardForm: string => unit,
   launchWidgetPaymentSheet: (string, Dict.t<JSON.t> => unit) => unit,
+  onAddPaymentMethod: string => unit,
   exitWidgetPaymentsheet: (int, string, bool) => unit,
 }
 
@@ -42,6 +43,7 @@ let hyperModule = {
     _,
     _,
   ) => ()),
+  onAddPaymentMethod: getFunctionFromModule(hyperModuleDict, "onAddPaymentMethod", _ => ()),
   exitWidgetPaymentsheet: getFunctionFromModule(hyperModuleDict, "exitWidgetPaymentsheet", (
     _,
     _,

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -864,34 +864,12 @@ let useSavePaymentMethod = () => {
   let baseUrl = GlobalHooks.useGetBaseUrl()()
   let apiLogWrapper = LoggerHook.useApiLogWrapper()
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (cardData, _) = React.useContext(CardDataContext.cardDataContext)
 
-  let (month, year) = Validation.getExpiryDates(cardData.expireDate)
-  let payment_method_data =
-    [
-      (
-        "card",
-        [
-          ("card_number", cardData.cardNumber->Validation.clearSpaces->JSON.Encode.string),
-          ("card_exp_month", month->JSON.Encode.string),
-          ("card_exp_year", year->JSON.Encode.string),
-        ]
-        ->Dict.fromArray
-        ->JSON.Encode.object,
-      ),
-    ]
-    ->Dict.fromArray
-    ->JSON.Encode.object
-
-  let body: PaymentMethodListType.redirectType = {
-    payment_method: "card",
-    client_secret: nativeProp.pmClientSecret->Option.getOr(""),
-    payment_method_data,
-  }
-
-  () => {
-    let paymentMethodId = nativeProp.paymentMethodManagementId->Option.getOr("")
-    let uri = `${baseUrl}/payment_methods/${paymentMethodId}/save`
+  (
+    ~body: PaymentMethodListType.redirectType
+  ) => {
+    let uriParam = nativeProp.paymentMethodId
+    let uri = `${baseUrl}/payment_methods/${uriParam}/save`
     apiLogWrapper(
       ~logType=INFO,
       ~eventName=ADD_PAYMENT_METHOD_CALL_INIT,

--- a/src/pages/paymentMethodsManagement/PaymentMethodListItem.res
+++ b/src/pages/paymentMethodsManagement/PaymentMethodListItem.res
@@ -8,7 +8,9 @@ module AddPaymentMethodButton = {
     let localeObject = GetLocale.useGetLocalObj()
 
     <CustomTouchableOpacity
-      onPress={_ => ()} // TODO: navigate to ADD_PM_SCREEN
+      onPress={_ => (
+        HyperModule.hyperModule.onAddPaymentMethod("")
+      )}
       style={viewStyle(
         ~paddingVertical=16.->dp,
         ~paddingHorizontal=24.->dp,
@@ -16,9 +18,6 @@ module AddPaymentMethodButton = {
         ~borderBottomColor=component.borderColor,
         ~flexDirection=#row,
         ~flexWrap=#nowrap,
-        ~alignItems=#center,
-        ~justifyContent=#"space-between",
-        ~flex=1.,
         (),
       )}>
       <View
@@ -26,7 +25,7 @@ module AddPaymentMethodButton = {
           ~flexDirection=#row,
           ~flexWrap=#nowrap,
           ~alignItems=#center,
-          ~flex=4.,
+          ~flex=1.,
           (),
         )}>
         <Icon

--- a/src/pages/paymentMethodsManagement/PaymentMethodsManagement.res
+++ b/src/pages/paymentMethodsManagement/PaymentMethodsManagement.res
@@ -112,14 +112,20 @@ let make = () => {
         <Space height=200. />
       </ScrollView>
     </View>
-    : <View
-        style={viewStyle(
-          ~backgroundColor=component.background,
-          ~flex=1.,
-          ~alignItems=#center,
-          ~justifyContent=#center,
-          (),
-        )}>
-        <TextWrapper text={"No saved payment methods available."} textType={CardText} />
-      </View>
+    : <>
+        <View
+          style={viewStyle(
+            ~width=100.->pct,
+            ~paddingVertical=24.->dp,
+            ~paddingHorizontal=24.->dp,
+            ~borderBottomWidth=0.8,
+            ~borderBottomColor=component.borderColor,
+            ~backgroundColor=component.background,
+            ~alignItems=#center,
+            (),
+          )}>
+          <TextWrapper text={"No saved payment methods available."} textType={ModalTextLight} />
+        </View>
+        <PaymentMethodListItem.AddPaymentMethodButton />
+      </>
 }

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -307,9 +307,8 @@ type hyperParams = {
 type nativeProp = {
   publishableKey: string,
   clientSecret: string,
+  paymentMethodId: string,
   ephemeralKey: option<string>,
-  paymentMethodManagementId: option<string>,
-  pmClientSecret: option<string>,
   customBackendUrl: option<string>,
   customLogUrl: option<string>,
   sessionId: string,
@@ -893,9 +892,10 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
     rootTag,
     publishableKey,
     clientSecret: getString(dictfromNative, "clientSecret", ""),
+    paymentMethodId: String.split(getString(dictfromNative, "clientSecret", ""), "_secret_")
+    ->Array.get(0)
+    ->Option.getOr(""),
     ephemeralKey: getOptionString(dictfromNative, "ephemeralKey"),
-    paymentMethodManagementId: getOptionString(dictfromNative, "paymentMethodId"),
-    pmClientSecret: getOptionString(dictfromNative, "pmClientSecret"),
     customBackendUrl,
     customLogUrl,
     sessionId: "",


### PR DESCRIPTION
## SCREEN RECORDING
This video depicts:
1. Delete a saved payment method.
2. Save a new payment method using **"$0 payment"** flow.
3. Use the saved payment method to process the payment.

https://github.com/user-attachments/assets/3dc9d04a-1c69-42f2-b4ae-06c1c934c693



## ADDED 
- native callback for handling clicks on `Add new payment method`.

## FIXED
- UI fix to display "Add pm button" in case of no saved-pms.

| Before                                                                                                  | After                                                                                                   |
|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
| <img width=350 src="https://github.com/user-attachments/assets/3d43a75b-ccb4-4372-9b6c-c3eb0ac9a614" /> | <img width=350 src="https://github.com/user-attachments/assets/ef98e3c3-23c9-4601-ab40-0276e715638c" /> |



