### PR TITLE
fix: native navigation overlapping with confirm btn

### DIFF
--- a/src/routes/FullScreenSheetWrapper.res
+++ b/src/routes/FullScreenSheetWrapper.res
@@ -52,6 +52,16 @@ let make = (~children) => {
     None
   }, [loading])
 
+  let navigationBarHeight = React.useMemo(() => {
+    if Platform.os !== #android {
+      0.
+    } else {
+      let screenHeight = Dimensions.get(#screen).height
+      let windowHeight = Dimensions.get(#window).height
+      screenHeight -. windowHeight
+    }
+  }, [])
+
   <View
     style={viewStyle(
       ~flex=1.,
@@ -68,7 +78,10 @@ let make = (~children) => {
         (),
       )}>
       <CustomView onDismiss=onModalClose>
-        <CustomView.Wrapper onModalClose> {children} </CustomView.Wrapper>
+        <CustomView.Wrapper onModalClose>
+          {children}
+          <Space height={navigationBarHeight} />
+        </CustomView.Wrapper>
       </CustomView>
     </Animated.View>
     <LoadingOverlay />

--- a/src/routes/ParentPaymentSheet.res
+++ b/src/routes/ParentPaymentSheet.res
@@ -39,6 +39,6 @@ let make = () => {
     | (None, _) => <PaymentSheet setConfirmButtonDataRef />
     }}
     <GlobalConfirmButton confirmButtonDataRef />
-    <Space height=12. />
+    <Space height=15. />
   </FullScreenSheetWrapper>
 }


### PR DESCRIPTION
# FIXED
- Android navigation bar overlapping with confirm button.
https://juspay.slack.com/archives/C065UPRTBQX/p1734595955753859?thread_ts=1734594737.221729&cid=C065UPRTBQX

# SCREENSHOT
### android - Device: Pixel 8a
| With card form         | <img src="https://github.com/user-attachments/assets/9569bf67-1ab5-4d7f-8e4c-3e5650196c44" width=250 /> | <img src="https://github.com/user-attachments/assets/18292c18-5794-4797-8ea3-c2fa93f12fdb" width=250 /> |
|------------------------|---------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
| only with card-element | <img src="https://github.com/user-attachments/assets/f7a42887-2432-442d-a25f-4908300bc59a" width=250 /> | <img src="https://github.com/user-attachments/assets/b688d22e-345c-4da5-9276-fc3f6d48170c" width=250 /> |

### iOS
<img src="https://github.com/user-attachments/assets/11a071af-e96a-4043-af3f-f4558f560946" width=250 />



