### PR TITLE
fix: co-badged card selection when disabled

### DIFF
--- a/src/components/elements/CardElement.res
+++ b/src/components/elements/CardElement.res
@@ -65,11 +65,35 @@ let make = (
     }
     None
   }, [reset])
+
+  React.useEffect(() => {
+    switch cardData.selectedCoBadgedCardBrand {
+    | Some(cardBrand) => {
+        let num = cardData.cardNumber
+        let isthisValid = cardValid(num, cardBrand)
+        let isSupported = switch cardNetworks {
+        | Some(networks) => isCardBrandSupported(~cardBrand, ~cardNetworks=networks)
+        | None => true
+        }
+
+        setCardData(prev => {
+          ...prev,
+          isCardNumberValid: Some(isthisValid),
+          isCardBrandSupported: Some(isSupported),
+          cardBrand,
+        })
+      }
+    | None => ()
+    }
+
+    None
+  }, [cardData.selectedCoBadgedCardBrand])
+
   let onChangeCardNumber = (
     text,
     expireRef: React.ref<Nullable.t<ReactNative.TextInput.element>>,
   ) => {
-    let cardBrand = getCardBrand(text)
+    let cardBrand = cardData.selectedCoBadgedCardBrand->Option.getOr(getCardBrand(text))
     let num = formatCardNumber(text, cardType(cardBrand))
 
     let isthisValid = cardValid(num, cardBrand)
@@ -193,7 +217,6 @@ let make = (
         isCardBrandSupported=cardData.isCardBrandSupported
         isCvvValid=cardData.isCvvValid
         keyToTrigerButtonClickError
-        cardNetworks
       />
     | CardForm(_) =>
       <CardFormUi

--- a/src/components/elements/CardSchemeComponent.res
+++ b/src/components/elements/CardSchemeComponent.res
@@ -43,7 +43,7 @@ module CardSchemeSelectionPopoverElement = {
 }
 
 @react.component
-let make = (~cardNumber, ~cardNetworks) => {
+let make = (~cardNumber) => {
   let (cardData, setCardData) = React.useContext(CardDataContext.cardDataContext)
 
   let cardBrand = Validation.getCardBrand(cardNumber)
@@ -51,21 +51,7 @@ let make = (~cardNumber, ~cardNetworks) => {
     cardBrand === "" ? "waitcard" : cardBrand
   )
   let (dropDownIconWidth, _) = React.useState(_ => Animated.Value.create(0.))
-
-  let getCardNetworks = cardNetworks => {
-    switch cardNetworks {
-    | Some(cardNetworks) =>
-      cardNetworks->Array.map((item: PaymentMethodListType.card_networks) => item.card_network)
-    | None => []
-    }
-  }
-
-  let enabledCardSchemes = getCardNetworks(cardNetworks->Option.getOr(None))
   let matchedCardSchemes = cardNumber->Validation.clearSpaces->Validation.getAllMatchedCardSchemes
-  let eligibleCardSchemes = Validation.getEligibleCoBadgedCardSchemes(
-    ~matchedCardSchemes,
-    ~enabledCardSchemes,
-  )
 
   let setCardBrand = cardBrand => {
     setCardBrandIcon(_ => cardBrand)
@@ -75,19 +61,19 @@ let make = (~cardNumber, ~cardNetworks) => {
     })
   }
 
-  let isCardCoBadged = eligibleCardSchemes->Array.length > 1
+  let isCardCoBadged = matchedCardSchemes->Array.length > 1
   let showCardSchemeDropDown =
     isCardCoBadged && cardNumber->Validation.clearSpaces->String.length >= 16
 
   let selectedCardBrand =
-    eligibleCardSchemes->Array.includes(cardData.selectedCoBadgedCardBrand->Option.getOr(cardBrand))
+    matchedCardSchemes->Array.includes(cardData.selectedCoBadgedCardBrand->Option.getOr(cardBrand))
       ? cardData.selectedCoBadgedCardBrand->Option.getOr(cardBrand)
       : cardBrand
 
   React.useEffect(() => {
     setCardBrandIcon(_ => selectedCardBrand === "" ? "waitcard" : selectedCardBrand)
     None
-  }, (cardBrand, eligibleCardSchemes, selectedCardBrand))
+  }, (cardBrand, matchedCardSchemes, selectedCardBrand))
 
   React.useEffect(() => {
     setCardData(prev => {
@@ -121,7 +107,7 @@ let make = (~cardNumber, ~cardNetworks) => {
       maxWidth=200.
       maxHeight=180.
       renderContent={toggleVisibility =>
-        <CardSchemeSelectionPopoverElement eligibleCardSchemes setCardBrand toggleVisibility />}>
+        <CardSchemeSelectionPopoverElement eligibleCardSchemes=matchedCardSchemes setCardBrand toggleVisibility />}>
       <View
         style={viewStyle(
           ~display=#flex,

--- a/src/components/elements/PaymentSheetUi.res
+++ b/src/components/elements/PaymentSheetUi.res
@@ -16,7 +16,6 @@ let make = (
   ~isCvvValid,
   ~onScanCard,
   ~keyToTrigerButtonClickError,
-  ~cardNetworks,
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   let isCardNumberValid = isCardNumberValid->Option.getOr(true)
@@ -95,10 +94,10 @@ let make = (
     None
   }, [keyToTrigerButtonClickError])
 
-  let getScanCardComponent = (isScanCardAvailable, cardNumber, cardNetworks) => {
+  let getScanCardComponent = (isScanCardAvailable, cardNumber) => {
     CustomInput.CustomIcon(
       <View style={array([viewStyle(~flexDirection=#row, ~alignItems=#center, ())])}>
-        <CardSchemeComponent cardNumber cardNetworks />
+        <CardSchemeComponent cardNumber />
         <UIUtils.RenderIf condition={isScanCardAvailable && cardNumber === ""}>
           {<>
             <View
@@ -160,7 +159,7 @@ let make = (
           borderBottomRightRadius=0.
           textColor={isCardNumberValid ? component.color : dangerColor}
           enableCrossIcon=false
-          iconRight={getScanCardComponent(ScanCardModule.isAvailable, cardNumber, cardNetworks)}
+          iconRight={getScanCardComponent(ScanCardModule.isAvailable, cardNumber)}
           onFocus={() => {
             setCardNumberIsFocus(_ => true)
             onChangeCardNumber(cardNumber, nullRef)

--- a/src/utility/reusableCodeFromWeb/Validation.res
+++ b/src/utility/reusableCodeFromWeb/Validation.res
@@ -146,11 +146,11 @@ let getAllMatchedCardSchemes = cardNumber => {
   })
 }
 
-let getEligibleCoBadgedCardSchemes = (~matchedCardSchemes, ~enabledCardSchemes) => {
-  matchedCardSchemes->Array.filter(ele => 
-    enabledCardSchemes->Array.includes(ele)
-  )
-}
+// let getEligibleCoBadgedCardSchemes = (~matchedCardSchemes, ~enabledCardSchemes) => {
+//   matchedCardSchemes->Array.filter(ele => 
+//     enabledCardSchemes->Array.includes(ele)
+//   )
+// }
 
 let getCardBrand = cardNumber => {
   try {


### PR DESCRIPTION
## FIXED
- For a cobadge card, which supports Visa and Cartes Bancaires, if we disabled Visa from the backend and enabled only Cartes Bancaires. As a result, Cartes Bancaires appears in the available payment methods. However, when we enter the card number, it displays an error stating that the card brand is not supported.

