### PR TITLE
fix: co-badged card selection when priority scheme disabled

### DIFF
--- a/src/components/elements/CardElement.res
+++ b/src/components/elements/CardElement.res
@@ -69,7 +69,9 @@ let make = (
     text,
     expireRef: React.ref<Nullable.t<ReactNative.TextInput.element>>,
   ) => {
-    let cardBrand = getCardBrand(text)
+    let enabledCardSchemes = PaymentUtils.getCardNetworks(cardNetworks->Option.getOr(None))
+    let validCardBrand = getFirstValidCardScheme(~cardNumber=text, ~enabledCardSchemes)
+    let cardBrand = validCardBrand === "" ? getCardBrand(text) : validCardBrand
     let num = formatCardNumber(text, cardType(cardBrand))
 
     let isthisValid = cardValid(num, cardBrand)

--- a/src/components/elements/CardSchemeComponent.res
+++ b/src/components/elements/CardSchemeComponent.res
@@ -46,21 +46,14 @@ module CardSchemeSelectionPopoverElement = {
 let make = (~cardNumber, ~cardNetworks) => {
   let (cardData, setCardData) = React.useContext(CardDataContext.cardDataContext)
 
-  let cardBrand = Validation.getCardBrand(cardNumber)
+  let enabledCardSchemes = PaymentUtils.getCardNetworks(cardNetworks->Option.getOr(None))
+  let validCardBrand = Validation.getFirstValidCardScheme(~cardNumber, ~enabledCardSchemes)
+  let cardBrand = validCardBrand === "" ? Validation.getCardBrand(cardNumber) : validCardBrand
   let (cardBrandIcon, setCardBrandIcon) = React.useState(_ =>
     cardBrand === "" ? "waitcard" : cardBrand
   )
   let (dropDownIconWidth, _) = React.useState(_ => Animated.Value.create(0.))
 
-  let getCardNetworks = cardNetworks => {
-    switch cardNetworks {
-    | Some(cardNetworks) =>
-      cardNetworks->Array.map((item: PaymentMethodListType.card_networks) => item.card_network)
-    | None => []
-    }
-  }
-
-  let enabledCardSchemes = getCardNetworks(cardNetworks->Option.getOr(None))
   let matchedCardSchemes = cardNumber->Validation.clearSpaces->Validation.getAllMatchedCardSchemes
   let eligibleCardSchemes = Validation.getEligibleCoBadgedCardSchemes(
     ~matchedCardSchemes,

--- a/src/types/SamsungPayType.res
+++ b/src/types/SamsungPayType.res
@@ -135,7 +135,6 @@ let getShippingDetails = (dict): SdkTypes.addressDetails => {
     ->Option.getOr(Dict.make())
 
   let fullName = getString(shippingDict, "addressee", "")
-  Console.log2("FullName", fullName)
 
   let nameArr = String.split(fullName, " ")
   let firstName = nameArr[0]->Option.getOr("")

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -181,3 +181,11 @@ let getActionType = (nextActionObj: option<PaymentConfirmTypes.nextAction>) => {
   let actionType = nextActionObj->Option.getOr({type_: "", redirectToUrl: ""})
   actionType.type_
 }
+
+let getCardNetworks = cardNetworks => {
+  switch cardNetworks {
+  | Some(cardNetworks) =>
+    cardNetworks->Array.map((item: PaymentMethodListType.card_networks) => item.card_network)
+  | None => []
+  }
+}

--- a/src/utility/reusableCodeFromWeb/Validation.res
+++ b/src/utility/reusableCodeFromWeb/Validation.res
@@ -146,10 +146,19 @@ let getAllMatchedCardSchemes = cardNumber => {
   })
 }
 
+let isCardSchemeEnabled = (~cardScheme, ~enabledCardSchemes) => {
+  enabledCardSchemes->Array.includes(cardScheme)
+}
+
+let getFirstValidCardScheme = (~cardNumber, ~enabledCardSchemes) => {
+  let allMatchedCards = getAllMatchedCardSchemes(cardNumber->clearSpaces)
+  allMatchedCards
+  ->Array.find(card => isCardSchemeEnabled(~cardScheme=card, ~enabledCardSchemes))
+  ->Option.getOr("")
+}
+
 let getEligibleCoBadgedCardSchemes = (~matchedCardSchemes, ~enabledCardSchemes) => {
-  matchedCardSchemes->Array.filter(ele => 
-    enabledCardSchemes->Array.includes(ele)
-  )
+  matchedCardSchemes->Array.filter(ele => enabledCardSchemes->Array.includes(ele))
 }
 
 let getCardBrand = cardNumber => {


### PR DESCRIPTION
## FIXED
- For a cobadge card, which supports Visa and Cartes Bancaires, if we disabled Visa from the backend and enabled only Cartes Bancaires. As a result, Cartes Bancaires appears in the available payment methods. However, when we enter the card number, it displays an error stating that the card brand is not supported.
