### PR TITLE
refactor: changed the naming convention for display_name for BECS PM

### DIFF
--- a/src/components/common/DynamicFields.res
+++ b/src/components/common/DynamicFields.res
@@ -184,7 +184,7 @@ module RenderField = {
     }
     let onChange = text => {
       setVal(prev =>
-        RequiredFieldsTypes.onlyDigits_restrictsChars(
+        RequiredFieldsTypes.allowOnlyDigits(
           ~text,
           ~fieldType=required_fields_type.field_type,
           ~prev,

--- a/src/types/RequiredFieldsTypes.res
+++ b/src/types/RequiredFieldsTypes.res
@@ -250,7 +250,7 @@ let numberOfDigitsValidation = (
         localeObject.enterValidDigitsText ++ " " ++
         digits->Int.toString ++
         localeObject.digitsText ++ " " ++
-        display_name->Option.getOr("")->Utils.toCamelCase,
+        display_name->Option.getOr("")->Utils.underscoresToSpaces,
       )
     }
   } else {
@@ -286,7 +286,7 @@ let checkIsValid = (
   }
 }
 
-let onlyDigits_restrictsChars = (
+let allowOnlyDigits = (
   ~text,
   ~fieldType,
   ~prev,
@@ -318,6 +318,8 @@ let onlyDigits_restrictsChars = (
 let getKeyboardType = (~field_type: paymentMethodsFields) => {
   switch field_type {
   | Email => #"email-address"
+  | AccountNumber => #"number-pad"
+  | BSBNumber => #"number-pad"
   | _ => #default
   }
 }

--- a/src/utility/logics/Utils.res
+++ b/src/utility/logics/Utils.res
@@ -218,6 +218,11 @@ let getStringFromJson = (json, default) => {
   json->JSON.Decode.string->Option.getOr(default)
 }
 
+let underscoresToSpaces = str => {
+    str
+    ->String.replaceAll("_", " ")
+}
+
 let toCamelCase = str => {
   if str->String.includes(":") {
     str


### PR DESCRIPTION
### Changes Made:

1. **Updated Keyboard Type**  
   - Set **Number Pad** input type for:
     - `Account Number`
     - `BSB Number`  
   (Becs payment method)

2. **Improved Display Name Formatting**  
   - Previously: Converted `display_name` to **camelCase**  
     - Example: `bank_account_number` → `bankAccountNumber`
   - Now: Converted `display_name` to **readable text**  
     - Example: `bank_account_number` → `bank account number`
