### PR TITLE
fix: active opacity issue for picker component

### DIFF
--- a/src/components/common/CustomPicker.res
+++ b/src/components/common/CustomPicker.res
@@ -31,6 +31,7 @@ let make = (
     None
   }, [isCountryStateFields])
   let pickerRef = React.useRef(Nullable.null)
+  let searchInputRef = React.useRef(Nullable.null)
   let {
     bgColor,
     component,
@@ -47,7 +48,7 @@ let make = (
     None
   }, [isModalVisible])
   <View>
-    <CustomTouchableOpacity disabled onPress={_ => setIsModalVisible(prev => !prev)}>
+    <CustomTouchableOpacity disabled activeOpacity=1. onPress={_ => setIsModalVisible(prev => !prev)}>
       <CustomInput
         state={switch items->Array.find(x => x.value == value->Option.getOr("")) {
         | Some(y) => y.label
@@ -74,7 +75,18 @@ let make = (
         pointerEvents={#none}
       />
     </CustomTouchableOpacity>
-    <Modal visible={isModalVisible} transparent={true} animationType=#slide>
+    <Modal
+      visible={isModalVisible}
+      transparent={true}
+      animationType=#slide
+      onShow={() => {
+        let _ = setTimeout(() => {
+          switch searchInputRef.current->Nullable.toOption{
+          | Some(input) => input->TextInputElement.focus
+          | None => ()
+          }
+        }, 300)
+      }}>
       <SafeAreaView />
       <View style={array([viewStyle(~flex=1., ~paddingTop=24.->dp, ()), transparentBG])}>
         <View
@@ -108,6 +120,7 @@ let make = (
             </CustomTouchableOpacity>
           </View>
           <CustomInput
+            reference={Some(searchInputRef)}
             placeholder={"Search " ++ placeholderText} // MARK: add Search to locale
             state={searchInput->Option.getOr("")}
             setState={val => {

--- a/src/pages/payment/SaveCardsList.res
+++ b/src/pages/payment/SaveCardsList.res
@@ -43,7 +43,8 @@ module CVVComponent = {
               <CustomInput
                 state={isPaymentMethodSelected ? savedCardCvv->Option.getOr("") : ""}
                 setState={isPaymentMethodSelected ? onCvvChange : _ => ()}
-                placeholder="CVC"
+                placeholder="123"
+                animateLabel="CVC"
                 fontSize=12.
                 keyboardType=#"number-pad"
                 enableCrossIcon=false

--- a/src/pages/payment/SaveCardsList.res
+++ b/src/pages/payment/SaveCardsList.res
@@ -43,7 +43,7 @@ module CVVComponent = {
               <CustomInput
                 state={isPaymentMethodSelected ? savedCardCvv->Option.getOr("") : ""}
                 setState={isPaymentMethodSelected ? onCvvChange : _ => ()}
-                placeholder="123"
+                placeholder="CVC"
                 fontSize=12.
                 keyboardType=#"number-pad"
                 enableCrossIcon=false
@@ -251,7 +251,7 @@ module PaymentMethodListView = {
         ~justifyContent=#center,
         (),
       )}
-      activeOpacity=0.7>
+      activeOpacity=1.>
       <View
         style={viewStyle(
           ~flexDirection=#row,


### PR DESCRIPTION
## Changes

1. Fixed unintended thick border issue:
     -  Previously, fields like CVC input in the Saved Cards screen and Picker components were displaying an unintended thick border.
     - Replaced the CVC placeholder from **123** to **CVC**
2. Added auto-focus behavior for Picker components:   
     - When a Picker modal opens, the search input field inside the modal will now automatically receive focus.


https://github.com/user-attachments/assets/408f1755-1d5c-443b-8b0a-bc2e3aa3c236












