### PR TITLE
Sending state code to the backend for Wallets and card payment

### DIFF
--- a/src/components/common/DynamicFields.res
+++ b/src/components/common/DynamicFields.res
@@ -9,7 +9,7 @@ module RenderField = {
     ->Array.map((item): CustomPicker.customPickerType => {
       {
         label: item.label != "" ? item.label ++ " - " ++ item.value : item.value,
-        value: item.value,
+        value: item.code,
       }
     })
   }

--- a/src/components/elements/ButtonElement.res
+++ b/src/components/elements/ButtonElement.res
@@ -231,7 +231,6 @@ let make = (
     }
   }
 
-  let (countryStateData, _) = React.useContext(CountryStateDataContext.countryStateDataContext)
 
   let confirmGPay = var => {
     let paymentData = var->PaymentConfirmTypes.itemToObjMapperJava
@@ -241,14 +240,7 @@ let make = (
       let obj =
         json
         ->Utils.getDictFromJson
-        ->GooglePayTypeNew.itemToObjMapper(
-          switch countryStateData {
-          | FetchData(data)
-          | Localdata(data) =>
-            data.states
-          | _ => Dict.make()
-          },
-        )
+        ->GooglePayTypeNew.itemToObjMapper
       let billingAddress = switch obj.paymentMethodData.info {
       | Some(info) => info.billing_address
 
@@ -385,24 +377,8 @@ let make = (
           let payment_data = var->Dict.get("payment_data")->Option.getOr(JSON.Encode.null)
           let payment_method = var->Dict.get("payment_method")->Option.getOr(JSON.Encode.null)
 
-          let billingAddress = var->GooglePayTypeNew.getBillingContact(
-            "billing_contact",
-            switch countryStateData {
-            | FetchData(data)
-            | Localdata(data) =>
-              data.states
-            | _ => Dict.make()
-            },
-          )
-          let shippingAddress = var->GooglePayTypeNew.getBillingContact(
-            "shipping_contact",
-            switch countryStateData {
-            | FetchData(data)
-            | Localdata(data) =>
-              data.states
-            | _ => Dict.make()
-            },
-          )
+          let billingAddress = var->GooglePayTypeNew.getBillingContact("billing_contact")
+          let shippingAddress = var->GooglePayTypeNew.getBillingContact("shippingAddress")
           let paymentData =
             [
               ("payment_data", payment_data),

--- a/src/headless/Headless.res
+++ b/src/headless/Headless.res
@@ -31,12 +31,7 @@ let registerHeadless = headless => {
     })
     ->ignore
 
-  let confirmGPay = (
-    var,
-    statesJson: option<CountryStateDataHookTypes.states>,
-    data,
-    nativeProp,
-  ) => {
+  let confirmGPay = (var, data, nativeProp) => {
     let paymentData = var->PaymentConfirmTypes.itemToObjMapperJava
     switch paymentData.error {
     | "" =>
@@ -44,7 +39,7 @@ let registerHeadless = headless => {
       let obj =
         json
         ->Utils.getDictFromJson
-        ->GooglePayTypeNew.itemToObjMapper(statesJson->Option.getOr(Dict.make()))
+        ->GooglePayTypeNew.itemToObjMapper
 
       let payment_method_data =
         [
@@ -118,7 +113,7 @@ let registerHeadless = headless => {
     }
   }
 
-  let confirmApplePay = (var, statesJson, data, nativeProp) => {
+  let confirmApplePay = (var,data, nativeProp) => {
     switch var
     ->Dict.get("status")
     ->Option.getOr(JSON.Encode.null)
@@ -173,10 +168,7 @@ let registerHeadless = headless => {
             ),
             (
               "billing",
-              switch var->GooglePayTypeNew.getBillingContact(
-                "billing_contact",
-                statesJson->Option.getOr(Dict.make()),
-              ) {
+              switch var->GooglePayTypeNew.getBillingContact("billing_contact") {
               | Some(billing) => billing->Utils.getJsonObjectFromRecord
               | None => JSON.Encode.null
               },
@@ -268,13 +260,12 @@ let registerHeadless = headless => {
             RequiredFieldsTypes.importStatesAndCountries(
               "./../utility/reusableCodeFromWeb/StatesAndCountry.json",
             )
-            ->Promise.then(res => {
-              let states = res->S3ApiHook.decodeJsonTocountryStateData
-              confirmGPay(var, Some(states.states), data, nativeProp)
+            ->Promise.then(_ => {
+              confirmGPay(var, data, nativeProp)
               Promise.resolve()
             })
             ->Promise.catch(_ => {
-              confirmGPay(var, None, data, nativeProp)
+              confirmGPay(var, data, nativeProp)
               Promise.resolve()
             })
             ->ignore
@@ -316,13 +307,12 @@ let registerHeadless = headless => {
             RequiredFieldsTypes.importStatesAndCountries(
               "./../utility/reusableCodeFromWeb/StatesAndCountry.json",
             )
-            ->Promise.then(res => {
-              let states = res->S3ApiHook.decodeJsonTocountryStateData
-              confirmApplePay(var, Some(states.states), data, nativeProp)
+            ->Promise.then(_ => {
+              confirmApplePay(var, data, nativeProp)
               Promise.resolve()
             })
             ->Promise.catch(_ => {
-              confirmApplePay(var, None, data, nativeProp)
+              confirmApplePay(var, data, nativeProp)
               Promise.resolve()
             })
             ->ignore

--- a/src/pages/payment/Redirect.res
+++ b/src/pages/payment/Redirect.res
@@ -538,7 +538,6 @@ let make = (
     }
   }
 
-  let (countryStateData, _) = React.useContext(CountryStateDataContext.countryStateDataContext)
 
   let confirmGPay = var => {
     let paymentData = var->PaymentConfirmTypes.itemToObjMapperJava
@@ -548,14 +547,7 @@ let make = (
       let obj =
         json
         ->Utils.getDictFromJson
-        ->GooglePayTypeNew.itemToObjMapper(
-          switch countryStateData {
-          | FetchData(data)
-          | Localdata(data) =>
-            data.states
-          | _ => Dict.make()
-          },
-        )
+        ->GooglePayTypeNew.itemToObjMapper
 
       let payment_method_data =
         [
@@ -614,24 +606,8 @@ let make = (
       } else {
         let payment_data = var->Dict.get("payment_data")->Option.getOr(JSON.Encode.null)
         let payment_method = var->Dict.get("payment_method")->Option.getOr(JSON.Encode.null)
-        let billingAddress = var->GooglePayTypeNew.getBillingContact(
-          "billing_contact",
-          switch countryStateData {
-          | FetchData(data)
-          | Localdata(data) =>
-            data.states
-          | _ => Dict.make()
-          },
-        )
-        let shippingAddress = var->GooglePayTypeNew.getBillingContact(
-          "shipping_contact",
-          switch countryStateData {
-          | FetchData(data)
-          | Localdata(data) =>
-            data.states
-          | _ => Dict.make()
-          },
-        )
+        let billingAddress = var->GooglePayTypeNew.getBillingContact("billing_contact")
+        let shippingAddress = var->GooglePayTypeNew.getBillingContact("shippingAddress")
         let paymentData =
           [
             ("payment_data", payment_data),

--- a/src/pages/payment/SavedPaymentScreen.res
+++ b/src/pages/payment/SavedPaymentScreen.res
@@ -65,7 +65,6 @@ let make = (
     )->Animated.start(~endCallback=_ => {endCallback()}, ())
   }
 
-  let (countryStateData, _) = React.useContext(CountryStateDataContext.countryStateDataContext)
 
   React.useEffect0(() => {
     setPaymentScreenType(SAVEDCARDSCREEN)
@@ -195,14 +194,7 @@ let make = (
       let obj =
         json
         ->Utils.getDictFromJson
-        ->GooglePayTypeNew.itemToObjMapper(
-          switch countryStateData {
-          | FetchData(data)
-          | Localdata(data) =>
-            data.states
-          | _ => Dict.make()
-          },
-        )
+        ->GooglePayTypeNew.itemToObjMapper
       let payment_method_data =
         [
           (
@@ -301,15 +293,7 @@ let make = (
             ),
             (
               "billing",
-              switch var->GooglePayTypeNew.getBillingContact(
-                "billing_contact",
-                switch countryStateData {
-                | FetchData(data)
-                | Localdata(data) =>
-                  data.states
-                | _ => Dict.make()
-                },
-              ) {
+              switch var->GooglePayTypeNew.getBillingContact("billing_contact") {
               | Some(billing) => billing->Utils.getJsonObjectFromRecord
               | None => JSON.Encode.null
               },
@@ -321,15 +305,7 @@ let make = (
           ~payment_method="wallet",
           ~payment_method_data,
           ~payment_method_type=selectedObj.walletName->SdkTypes.walletTypeToStrMapper,
-          ~email=?switch var->GooglePayTypeNew.getBillingContact(
-            "billing_contact",
-            switch countryStateData {
-            | FetchData(data)
-            | Localdata(data) =>
-              data.states
-            | _ => Dict.make()
-            },
-          ) {
+          ~email=?switch var->GooglePayTypeNew.getBillingContact("billing_contact") {
           | Some(billing) => billing.email
           | None => None
           },

--- a/src/types/GooglePayTypeNew.res
+++ b/src/types/GooglePayTypeNew.res
@@ -101,7 +101,7 @@ let getAssuranceDetails = (dict, str) => {
   })
 }
 
-let getBillingAddress = (dict, str, statesList) => {
+let getBillingAddress = (dict, str, _) => {
   dict
   ->Dict.get(str)
   ->Option.flatMap(JSON.Decode.object)
@@ -120,10 +120,7 @@ let getBillingAddress = (dict, str, statesList) => {
         line1: ?getOptionString(json, "address1"),
         line2: ?getOptionString(json, "address2"),
         zip: ?getOptionString(json, "postalCode"),
-        state: ?switch getOptionString(json, "administrativeArea") {
-        | Some(area) => Some(getStateNameFromStateCodeAndCountry(statesList, area, country))
-        | None => None
-        },
+        state: ?getOptionString(json, "administrativeArea"),
       }),
       email: getOptionString(json, "email"),
       phone: Some({
@@ -133,7 +130,7 @@ let getBillingAddress = (dict, str, statesList) => {
   })
 }
 
-let getBillingContact = (dict, str, statesList) => {
+let getBillingContact = (dict, str, _) => {
   dict
   ->Dict.get(str)
   ->Option.flatMap(JSON.Decode.object)
@@ -161,10 +158,7 @@ let getBillingContact = (dict, str, statesList) => {
         ?line1,
         ?line2,
         zip: ?getOptionString(postalAddress, "postalCode"),
-        state: ?switch getOptionString(postalAddress, "state") {
-        | Some(area) => Some(getStateNameFromStateCodeAndCountry(statesList, area, country))
-        | None => None
-        },
+        state: ?getOptionString(json, "administrativeArea"),
       }),
       email: getOptionString(json, "emailAddress"),
       phone: Some({

--- a/src/types/GooglePayTypeNew.res
+++ b/src/types/GooglePayTypeNew.res
@@ -101,7 +101,7 @@ let getAssuranceDetails = (dict, str) => {
   })
 }
 
-let getBillingAddress = (dict, str, _) => {
+let getBillingAddress = (dict, str) => {
   dict
   ->Dict.get(str)
   ->Option.flatMap(JSON.Decode.object)
@@ -130,7 +130,7 @@ let getBillingAddress = (dict, str, _) => {
   })
 }
 
-let getBillingContact = (dict, str, _) => {
+let getBillingContact = (dict, str) => {
   dict
   ->Dict.get(str)
   ->Option.flatMap(JSON.Decode.object)
@@ -168,7 +168,7 @@ let getBillingContact = (dict, str, _) => {
   })
 }
 
-let getInfo = (str, dict, statesJson) => {
+let getInfo = (str, dict) => {
   dict
   ->Dict.get(str)
   ->Option.flatMap(JSON.Decode.object)
@@ -177,7 +177,7 @@ let getInfo = (str, dict, statesJson) => {
       card_network: getString(json, "cardNetwork", ""),
       card_details: getString(json, "cardDetails", ""),
       assurance_details: ?getAssuranceDetails(json, "assuranceDetails"),
-      billing_address: ?getBillingAddress(json, "billingAddress", statesJson),
+      billing_address: ?getBillingAddress(json, "billingAddress"),
     }
   })
 }
@@ -193,12 +193,12 @@ let getTokenizationData = (str, dict) => {
     }
   })
 }
-let getPaymentMethodData = (str, dict, statesJson) => {
+let getPaymentMethodData = (str, dict) => {
   dict
   ->Dict.get(str)
   ->Option.flatMap(JSON.Decode.object)
   ->Option.map(json => {
-    let info = getInfo("info", json, statesJson)
+    let info = getInfo("info", json)
     {
       description: getString(json, "description", ""),
       tokenization_data: ?getTokenizationData("tokenizationData", json),
@@ -215,10 +215,10 @@ type paymentDataFromGPay = {
   shippingDetails?: addressDetails,
 }
 
-let itemToObjMapper = (dict, statesJson) => {
-  paymentMethodData: getPaymentMethodData("paymentMethodData", dict, statesJson),
+let itemToObjMapper = dict => {
+  paymentMethodData: getPaymentMethodData("paymentMethodData", dict),
   email: ?getOptionString(dict, "email"),
-  shippingDetails: ?getBillingAddress(dict, "shippingAddress", statesJson),
+  shippingDetails: ?getBillingAddress(dict, "shippingAddress"),
 }
 
 let arrayJsonToCamelCase = arr => {


### PR DESCRIPTION
-  **card payments** : We are sending the state code to the backend and checked in the confirm as well.(California -> CA).

- **Wallets** : The wallets were sending the state code to our SDK, we were sending the exact same data we collected from the wallet to the BE.

**TO DO :**  

1. we need to test apple pay and samsung pay. 
2. Also need to test no other payment methods getting effected.