### PR TITLE
fix: paddig b/w globalSubmit button and bottom navbar

### DIFF
--- a/src/contexts/ViewportContext.res
+++ b/src/contexts/ViewportContext.res
@@ -17,8 +17,8 @@ let statusBarHeight = ReactNative.StatusBar.currentHeight
 let navigationBarHeight = if ReactNative.Platform.os !== #android {
   defaultNavbarHeight
 } else {
-  let navigationHeight = screenHeight -. windowHeight -. statusBarHeight
-  Math.min(75., Math.max(0., navigationHeight) +. defaultNavbarHeight)
+  let navigationHeight = Math.max(0., screenHeight -. windowHeight -. statusBarHeight) +. defaultNavbarHeight
+  Math.max(Math.min(75., navigationHeight), 50.)
 }
 
 let maxPaymentSheetHeight = 95. // pct


### PR DESCRIPTION
### FIX
- Keep bottom safe-area between `50` and `75`, to avoid overlap of payment sheet contents and navigation bar in android-devices.