### PR TITLE
fix: remove wallet and other pm devider line in case when only wallet…

### DIFF
--- a/src/components/elements/SheetSeperation.res
+++ b/src/components/elements/SheetSeperation.res
@@ -1,0 +1,6 @@
+@react.component
+let make = () => {
+  let localeObject = GetLocale.useGetLocalObj()
+
+  <TextWithLine text=localeObject.orPayUsing />
+}

--- a/src/pages/hostedCheckout/HostedCheckoutSdk.res
+++ b/src/pages/hostedCheckout/HostedCheckoutSdk.res
@@ -14,6 +14,8 @@ let make = () => {
   <View style={s({maxWidth: 450.->dp, alignSelf: #center, width: 100.->pct})}>
     <Space height=20. />
     <WalletView elementArr />
+    <Space height=15. />
+    {tabArr->Array.length > 0 && elementArr->Array.length > 0 ? <SheetSeperation /> : React.null}
     <CustomTabView
       hocComponentArr=tabArr loading={allApiData.sessions == Loading} setConfirmButtonDataRef
     />

--- a/src/pages/payment/PaymentSheet.res
+++ b/src/pages/payment/PaymentSheet.res
@@ -27,6 +27,8 @@ let make = (~setConfirmButtonDataRef) => {
       elementArr
       showDisclaimer={allApiData.additionalPMLData.mandateType->PaymentUtils.checkIfMandate}
     />
+    <Space height=15. />
+    {tabArr->Array.length > 0 && elementArr->Array.length > 0 ? <SheetSeperation /> : React.null}
     <CustomTabView
       hocComponentArr=tabArr
       loading={allApiData.sessions == Loading && localeStrings == Loading}

--- a/src/pages/payment/WalletView.res
+++ b/src/pages/payment/WalletView.res
@@ -24,7 +24,6 @@ module WalletDisclaimer = {
 
 @react.component
 let make = (~loading=true, ~elementArr, ~showDisclaimer=false) => {
-  let localeObject = GetLocale.useGetLocalObj()
   <>
     {switch elementArr->Array.length {
     | 0 =>
@@ -32,8 +31,6 @@ let make = (~loading=true, ~elementArr, ~showDisclaimer=false) => {
         ? <>
             <Space />
             <CustomLoader />
-            <Space height=15. />
-            <TextWithLine text=localeObject.orPayUsing />
           </>
         : React.null
     | _ =>
@@ -41,8 +38,6 @@ let make = (~loading=true, ~elementArr, ~showDisclaimer=false) => {
         <Space />
         {elementArr->React.array}
         {showDisclaimer ? <WalletDisclaimer /> : React.null}
-        <Space height=15. />
-        <TextWithLine text=localeObject.orPayUsing />
       </>
     }}
   </>


### PR DESCRIPTION
## FIX 🐛 UI
- Removed the separator line "Or Pay Using", when only wallets are available and no other payment options are available, and vise-versa.


## TESTING
| Platform | Before                                                                                                                | After                                                                                                                 |
|----------|-----------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| Web      | <img width="450" alt="image" src="https://github.com/user-attachments/assets/c2893686-3aa8-4cf2-a283-9fab4317e104" /> | <img width="450" alt="image" src="https://github.com/user-attachments/assets/4579dbae-902c-4642-99f9-940bf70fe17f" /> |
| ios      | <img width="450" alt="image" src="https://github.com/user-attachments/assets/6e55099a-147b-485a-a588-230f9a581517" /> | <img width="450" alt="image" src="https://github.com/user-attachments/assets/0f196b10-bbdf-47ce-b557-68eb47b79859" /> |