### PR TITLE
fix: renamed APIUtils to APIHelper in shared-codebase

### DIFF
--- a/src/headless/HeadlessUtils.res
+++ b/src/headless/HeadlessUtils.res
@@ -13,7 +13,7 @@ let sendLogs = async (logFile, customLogUrl, env: GlobalVars.envType) => {
   if WebKit.platform != #next {
     let data = logFile->LoggerUtils.logFileToObj->JSON.stringify
     try {
-      let _ = await APIUtils.fetchApi(
+      let _ = await APIHelpers.fetchApi(
         ~uri,
         ~method_=Post,
         ~bodyStr=data,
@@ -146,7 +146,7 @@ let handleApiCall = async (
 
     | _ => ()
     }
-    let data = await APIUtils.fetchApi(
+    let data = await APIHelpers.fetchApi(
       ~uri,
       ~method_=method,
       ~headers,

--- a/src/hooks/AllPaymentHelperHooks.res
+++ b/src/hooks/AllPaymentHelperHooks.res
@@ -153,7 +153,7 @@ module RedirectionHooks = {
           }
         } else {
           try {
-            let jsonResponse = await APIUtils.fetchApiWrapper(
+            let jsonResponse = await APIHelpers.fetchApiWrapper(
               ~body,
               ~eventName=LoggerTypes.CONFIRM_CALL,
               ~headers,
@@ -170,7 +170,7 @@ module RedirectionHooks = {
 
       | _ =>
         try {
-          let jsonResponse = await APIUtils.fetchApiWrapper(
+          let jsonResponse = await APIHelpers.fetchApiWrapper(
             ~body,
             ~eventName=LoggerTypes.CONFIRM_CALL,
             ~headers,

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -36,7 +36,7 @@ let useSessionToken = () => {
     | _ =>
       let headers = Utils.getHeader(nativeProp.publishableKey, nativeProp.hyperParams.appId)
       let uri = `${baseUrl}/payments/session_tokens`
-      APIUtils.fetchApiWrapper(
+      APIHelpers.fetchApiWrapper(
         ~uri,
         ~body=PaymentUtils.generateSessionsTokenBody(
           ~clientSecret=nativeProp.clientSecret,
@@ -76,7 +76,7 @@ let useRetrieveHook = () => {
         )
       }
 
-      APIUtils.fetchApiWrapper(~uri, ~method=Get, ~headers, ~eventName, ~apiLogWrapper)
+      APIHelpers.fetchApiWrapper(~uri, ~method=Get, ~headers, ~eventName, ~apiLogWrapper)
     }
   }
 }
@@ -317,7 +317,7 @@ let useGetSavedPMHook = () => {
     switch WebKit.platform {
     | #next => Promise.resolve(Next.clistRes->Some)
     | _ =>
-      APIUtils.fetchApiOptionalWrapper(
+      APIHelpers.fetchApiOptionalWrapper(
         ~uri,
         ~method=Fetch.Get,
         ~headers=Utils.getHeader(apiKey, nativeProp.hyperParams.appId),
@@ -346,7 +346,7 @@ let useDeleteSavedPaymentMethod = () => {
     )
 
     if nativeProp.ephemeralKey->Option.isSome {
-      APIUtils.fetchApiOptionalWrapper(
+      APIHelpers.fetchApiOptionalWrapper(
         ~uri,
         ~method=Fetch.Delete,
         ~headers=Utils.getHeader(
@@ -371,7 +371,7 @@ let useSavePaymentMethod = () => {
     let uriParam = nativeProp.paymentMethodId
     let uri = `${baseUrl}/payment_methods/${uriParam}/save`
 
-    APIUtils.fetchApiOptionalWrapper(
+    APIHelpers.fetchApiOptionalWrapper(
       ~uri,
       ~method=Fetch.Post,
       ~headers=Utils.getHeader(nativeProp.publishableKey, nativeProp.hyperParams.appId),

--- a/src/hooks/NetceteraThreeDsHooks.res
+++ b/src/hooks/NetceteraThreeDsHooks.res
@@ -108,7 +108,7 @@ let useExternalThreeDs = () => {
         }
 
         let headers = getAuthCallHeaders(publishableKey)
-        APIUtils.fetchApi(~uri, ~headers, ~method_=Fetch.Get, ())
+        APIHelpers.fetchApi(~uri, ~headers, ~method_=Fetch.Get, ())
         ->Promise.then(data => {
           let statusCode = data->Fetch.Response.status->string_of_int
           if statusCode->String.charAt(0) === "2" {
@@ -227,7 +227,7 @@ let useExternalThreeDs = () => {
         (),
       )
       let headers = [("Content-Type", "application/json")]->Dict.fromArray
-      APIUtils.fetchApi(~uri=authorizeUrl, ~bodyStr="", ~headers, ~method_=Fetch.Post, ())
+      APIHelpers.fetchApi(~uri=authorizeUrl, ~bodyStr="", ~headers, ~method_=Fetch.Post, ())
       ->Promise.then(async data => {
         setLoading(ProcessingPayments)
         let statusCode = data->Fetch.Response.status->string_of_int
@@ -336,7 +336,7 @@ let useExternalThreeDs = () => {
         (),
       )
 
-      APIUtils.fetchApi(~uri, ~bodyStr, ~headers, ~method_=Post, ())
+      APIHelpers.fetchApi(~uri, ~bodyStr, ~headers, ~method_=Post, ())
       ->Promise.then(data => {
         let statusCode = data->Fetch.Response.status->string_of_int
         if statusCode->String.charAt(0) === "2" {

--- a/src/hooks/S3ApiHook.res
+++ b/src/hooks/S3ApiHook.res
@@ -307,7 +307,7 @@ let getLocaleStringsFromJson: Js.Json.t => localeStrings = jsonData => {
 
 //-
 let useFetchDataFromS3WithGZipDecoding = () => {
-  let apiFunction = APIUtils.fetchApi
+  let apiFunction = APIHelpers.fetchApi
   let logger = LoggerHook.useLoggerHook()
   let baseUrl = GlobalHooks.useGetAssetUrlWithVersion()()
 

--- a/src/utility/logics/LoggerUtils.res
+++ b/src/utility/logics/LoggerUtils.res
@@ -76,7 +76,7 @@ let sendLogs = (logFile, uri: option<string>, publishableKey, appId) => {
     | Some("") | None => ()
     | Some(uri) =>
       let data = logFile->logFileToObj->JSON.stringify
-      APIUtils.fetchApi(
+      APIHelpers.fetchApi(
         ~uri,
         ~method_=Post,
         ~bodyStr=data,


### PR DESCRIPTION
- Web SDK already had a file as APIUtils and shared-codebase also had a file as APIUtils so renamed it in shared-codebase from APIUtils to APIHelpers