### PR TITLE
docs: Add comprehensive Android IOs Integration setup guides

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,91 @@
+# Hyperswitch SDK Integration Guide
+
+This guide provides examples and steps to integrate the Hyperswitch Client Core SDK into your project across platforms.
+
+---
+
+## 1. Web Integration
+
+1. Install dependencies:
+
+```bash
+yarn install
+```
+2. Start the development server:
+
+```bash
+yarn run web
+```
+
+3. Import the SDK in your project:
+
+```javascript
+import Hyperswitch from 'hyperswitch-client-core';
+```
+4. Initialize the SDK:
+
+```javascript
+const sdk = new Hyperswitch({
+  apiKey: process.env.HYPERSWITCH_API_KEY,
+  environment: 'sandbox' // or 'production'
+});
+```
+5. Use SDK functions as needed:
+
+```javascript
+sdk.createPayment({...});
+sdk.getTransactionStatus(transactionId);
+```
+## 2. Android Integration
+
+1. Open the Android project in Android Studio.
+2. Ensure dependencies are installed:
+```bash
+yarn run build:android:detox
+```
+3. Initialize the SDK in your app:
+```java
+HyperswitchClient client = new HyperswitchClient.Builder()
+    .setApiKey("YOUR_API_KEY")
+    .setEnvironment(HyperswitchEnvironment.SANDBOX)
+    .build();
+```
+4. Use SDK methods to handle payments and transactions.
+
+## 3. iOS Integration
+
+1. Open the iOS project in Xcode (HyperswitchClientCore.xcworkspace).
+2. Ensure pods are installed:
+```bash
+cd ios
+pod install
+cd ..
+```
+
+3. Initialize the SDK in your app:
+```swift
+let client = HyperswitchClient(apiKey: "YOUR_API_KEY", environment: .sandbox)
+```
+
+4. Call SDK functions to handle payments and transactions.
+
+## 4. Common Integration Tips
+
+- Always use **environment variables** for sensitive keys.  
+- Test on **sandbox** first before switching to production.  
+- Use the **example apps** in the repository as references.  
+- If you make changes to the SDK, rebuild using:
+
+```bash
+yarn run build:web
+yarn run build:android:detox
+yarn run build:ios:detox
+```
+## 5. Troubleshooting
+
+| Issue                        | Solution                                                      |
+|-------------------------------|---------------------------------------------------------------|
+| SDK not found                  | Make sure submodules are initialized: `git submodule update --init --recursive` |
+| API errors                     | Check that the correct API key and environment are used      |
+| Build fails after SDK changes  | Rebuild the SDK for the platform you are targeting           |
+

--- a/docs/README-android.md
+++ b/docs/README-android.md
@@ -1,0 +1,76 @@
+# Android Development Setup Guide
+
+This guide will help you set up the Android environment for Hyperswitch Client Core step by step.
+
+---
+
+## 1. Install Android Studio
+
+1. Download Android Studio:
+   - [Windows/Mac/Linux link](https://developer.android.com/studio)
+2. Run the installer and follow the instructions for your OS.
+3. Launch Android Studio after installation.
+4. On the first run, allow it to download the required SDK components.
+
+---
+
+## 2. Install Java JDK 11+
+
+1. Download Java JDK 11 or higher:
+   - [Adoptium](https://adoptium.net/) or [Oracle JDK](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
+
+2. Set the JAVA_HOME environment variable:
+
+**Windows**
+```cmd
+setx JAVA_HOME "C:\Program Files\Java\jdk-11"
+```
+
+**Linux / Mac**
+```bash
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+```
+
+**Verify installation:**
+
+```bash
+java -version
+```
+
+## 3. Clone the Repository
+
+```bash
+git clone https://github.com/YOUR_USERNAME/hyperswitch-client-core.git
+cd hyperswitch-client-core
+git submodule update --init --recursive
+```
+
+## 4. Open Project in Android Studio
+
+1. Open Android Studio → Click **Open an existing project**  
+2. Select the cloned repo folder  
+3. Wait for Gradle to sync and download dependencies
+
+## 5. Run the App
+
+1. Connect a real device via USB **or** start an emulator:  
+   - Open Android Studio → Tools → AVD Manager → Start an emulator
+
+2. Click **Run → Run 'app'** or press **Shift + F10**
+
+## 6. Common Issues
+
+| Issue                 | Solution                                                        |
+|-----------------------|-----------------------------------------------------------------|
+| Gradle sync fails      | Check your internet connection; run `File → Sync Project with Gradle Files` |
+| Emulator not starting  | Make sure virtualization (VT-x/AMD-V) is enabled in BIOS       |
+| SDK not found          | Check Android SDK path in **File → Project Structure → SDK Location** |
+
+## 7. Tips
+
+- Use **Android Studio version 2022 or higher**.  
+- Always run `git submodule update --init --recursive` after cloning the repo.  
+- If you make changes to the SDK, rebuild using:  
+```bash
+yarn run build:android:detox
+```

--- a/docs/README-ios.md
+++ b/docs/README-ios.md
@@ -1,0 +1,64 @@
+# iOS Development Setup Guide
+
+This guide will help you set up the iOS environment for Hyperswitch Client Core step by step.
+
+---
+
+## 1. Install Xcode
+
+1. Download Xcode from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12)  
+2. Install Xcode and open it once to complete setup  
+3. Accept the license agreement if prompted  
+
+---
+
+## 2. Install CocoaPods
+
+CocoaPods is used for managing iOS dependencies:
+
+```bash
+sudo gem install cocoapods
+pod setup
+```
+## 3. Clone the Repository
+
+```bash
+git clone https://github.com/YOUR_USERNAME/hyperswitch-client-core.git
+cd hyperswitch-client-core
+git submodule update --init --recursive
+```
+## 4. Install iOS Dependencies
+
+```bash
+cd ios
+pod install
+cd ..
+```
+## 5. Open Project in Xcode
+
+1. Open HyperswitchClientCore.xcworkspace in Xcode
+2. Select the target device or simulator
+3. Wait for dependencies to load
+
+## 6. Run the App
+
+1. Choose a simulator or connect a real device
+2. Click the Run button (▶) in Xcode or press Cmd + R
+
+## 7. Common Issues
+
+| Issue                 | Solution                                                     |
+|-----------------------|--------------------------------------------------------------|
+| Pod install fails      | Run `pod repo update` and then `pod install` again          |
+| Simulator not starting | Restart Xcode or the simulator                               |
+| Build errors           | Clean the build folder: `Shift + Cmd + K`                   |
+
+## 8. Tips
+
+- Use **Xcode version 14 or higher**  
+- Always run `git submodule update --init --recursive` after cloning  
+- If you make changes to the SDK, rebuild using:  
+```bash
+yarn run build:ios:detox
+```
+


### PR DESCRIPTION
## Description
Fixes #363 

 Add comprehensive Android IOs Integration setup guides

## Changes
-  Added `docs/README-android.md` - Android development setup guide
-  Added `docs/README-ios.md` - iOS development setup guide
-  Added `docs/INTEGRATION.md` - Cross-platform integration guide