### PR TITLE
feat(superposition): integrate /sdk-configs endpoint for dynamic field rendering

### DIFF
--- a/mockServer.js
+++ b/mockServer.js
@@ -106,6 +106,13 @@ app.get('/health', (req, res) => {
   });
 });
 
+const superpositionConfig = require('./shared-code/assets/v1/configs/superposition.config.json');
+
+app.get('/get-config', (req, res) => {
+  logger.info('GET /get-config requested');
+  res.json(superpositionConfig);
+});
+
 app.get('/create-payment-intent', async (req, res) => {
   try {
     const paymentData = {

--- a/mockServer.js
+++ b/mockServer.js
@@ -108,8 +108,10 @@ app.get('/health', (req, res) => {
 
 const superpositionConfig = require('./shared-code/assets/v1/configs/superposition.config.json');
 
-app.get('/get-config', (req, res) => {
-  logger.info('GET /get-config requested');
+app.get('/v1/sdk/configs/:profileId/web/:env/:file', (req, res) => {
+  logger.info(
+    `GET /v1/sdk/configs/${req.params.profileId}/web/${req.params.env}/${req.params.file} requested`,
+  );
   res.json(superpositionConfig);
 });
 

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -906,13 +906,7 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
       topInset: getOptionFloat(hyperParams, "topInset"),
       leftInset: getOptionFloat(hyperParams, "leftInset"),
       rightInset: getOptionFloat(hyperParams, "rightInset"),
-      superpositionConfigRaw: switch getOptionString(hyperParams, "superpositionConfigRaw") {
-      | Some(jsonStr) =>
-        try {Some(jsonStr->JSON.parseExn)} catch {
-        | _ => None
-        }
-      | None => None
-      },
+      superpositionConfigRaw: getOptionJSON(hyperParams, "superpositionConfigRaw"),
     },
     customParams: getObj(dictfromNative, "customParams", Dict.make()),
   }

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -302,10 +302,7 @@ type hyperParams = {
   topInset: option<float>,
   leftInset: option<float>,
   rightInset: option<float>,
-}
-
-type superpositionConfig = {
-  configJson: option<JSON.t>,
+  superpositionConfigRaw: option<JSON.t>,
 }
 
 type nativeProp = {
@@ -323,7 +320,6 @@ type nativeProp = {
   rootTag: int,
   hyperParams: hyperParams,
   customParams: Dict.t<JSON.t>,
-  superpositionConfig: superpositionConfig,   // TODO: Move this inside hyperParams
 }
 
 let defaultAppearance: appearance = {
@@ -850,21 +846,6 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
   let configurationDict = getObj(dictfromNative, "configuration", Dict.make())
   let from = getOptionString(dictfromNative, "from")->Option.getOr("native")
 
-  let superpositionConfig = {
-    let rawConfigStr = getOptionString(dictfromNative, "superpositionConfigRaw")
-    let configJson = switch rawConfigStr {
-    | Some(jsonStr) =>
-      try {
-        let parsed = jsonStr->JSON.parseExn
-        Some(parsed)
-      } catch {
-      | _ => None
-      }
-    | None => None
-    }
-    {configJson: configJson}
-  }
-
   let publishableKey = getString(dictfromNative, "publishableKey", "")
   let customBackendUrl = switch getOptionString(dictfromNative, "customBackendUrl") {
   | Some("") => None
@@ -925,8 +906,14 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
       topInset: getOptionFloat(hyperParams, "topInset"),
       leftInset: getOptionFloat(hyperParams, "leftInset"),
       rightInset: getOptionFloat(hyperParams, "rightInset"),
+      superpositionConfigRaw: switch getOptionString(hyperParams, "superpositionConfigRaw") {
+      | Some(jsonStr) =>
+        try {Some(jsonStr->JSON.parseExn)} catch {
+        | _ => None
+        }
+      | None => None
+      },
     },
     customParams: getObj(dictfromNative, "customParams", Dict.make()),
-    superpositionConfig, 
   }
 }

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -304,6 +304,10 @@ type hyperParams = {
   rightInset: option<float>,
 }
 
+type superpositionConfig = {
+  configJson: option<JSON.t>,
+}
+
 type nativeProp = {
   publishableKey: string,
   clientSecret: string,
@@ -319,6 +323,7 @@ type nativeProp = {
   rootTag: int,
   hyperParams: hyperParams,
   customParams: Dict.t<JSON.t>,
+  superpositionConfig: superpositionConfig,   // TODO: Move this inside hyperParams
 }
 
 let defaultAppearance: appearance = {
@@ -845,6 +850,21 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
   let configurationDict = getObj(dictfromNative, "configuration", Dict.make())
   let from = getOptionString(dictfromNative, "from")->Option.getOr("native")
 
+  let superpositionConfig = {
+    let rawConfigStr = getOptionString(dictfromNative, "superpositionConfigRaw")
+    let configJson = switch rawConfigStr {
+    | Some(jsonStr) =>
+      try {
+        let parsed = jsonStr->JSON.parseExn
+        Some(parsed)
+      } catch {
+      | _ => None
+      }
+    | None => None
+    }
+    {configJson: configJson}
+  }
+
   let publishableKey = getString(dictfromNative, "publishableKey", "")
   let customBackendUrl = switch getOptionString(dictfromNative, "customBackendUrl") {
   | Some("") => None
@@ -907,5 +927,6 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
       rightInset: getOptionFloat(hyperParams, "rightInset"),
     },
     customParams: getObj(dictfromNative, "customParams", Dict.make()),
+    superpositionConfig, 
   }
 }

--- a/src/utility/logics/Utils.res
+++ b/src/utility/logics/Utils.res
@@ -23,6 +23,17 @@ let getOptionFloat = (dict, key) => {
   dict->Dict.get(key)->retOptionalFloat
 }
 
+let getOptionJSON = (dict, key) => {
+  dict
+  ->Dict.get(key)
+  ->Option.flatMap(JSON.Decode.string)
+  ->Option.flatMap(jsonStr =>
+    try {Some(jsonStr->JSON.parseExn)} catch {
+    | _ => None
+    }
+  )
+}
+
 let getString = (dict, key, default) => {
   getOptionString(dict, key)->Option.getOr(default)
 }


### PR DESCRIPTION
### Summary : 
- Phase 1 of Superposition integration. The SDK now fetches a dynamic field configuration from the new BE `/v1/sdk/configs/{profile_id}/web/{env}.json` endpoint at session init, and uses it to render payment method fields. Falls back to a bundled S3 config/local static file if the network call doesn't return in time.
- hyperParams.superpositionConfigRaw: option<JSON.t> plumbed through SdkTypes + Utils.getOptionJSON.