### PR TITLE
feat: widget confirm action listeners

### DIFF
--- a/src/components/modules/HyperModule.res
+++ b/src/components/modules/HyperModule.res
@@ -10,7 +10,7 @@ type hyperModule = {
   exitCardForm: string => unit,
   launchWidgetPaymentSheet: (string, Dict.t<JSON.t> => unit) => unit,
   onAddPaymentMethod: string => unit,
-  exitWidgetPaymentsheet: (int, string, bool) => unit,
+  exitWidgetPaymentsheet: (int, string, string, bool) => unit,
   updateWidgetHeight: int => unit,
 }
 
@@ -46,6 +46,7 @@ let hyperModule = {
   ) => ()),
   onAddPaymentMethod: getFunctionFromModule(hyperModuleDict, "onAddPaymentMethod", _ => ()),
   exitWidgetPaymentsheet: getFunctionFromModule(hyperModuleDict, "exitWidgetPaymentsheet", (
+    _,
     _,
     _,
     _,
@@ -101,6 +102,7 @@ let useExitPaymentsheet = () => {
           | WidgetPaymentSheet | WidgetButtonSheet =>
             hyperModule.exitWidgetPaymentsheet(
               nativeProp.rootTag,
+              nativeProp.widgetId,
               apiResStatus->stringifiedResStatus,
               reset,
             )
@@ -133,7 +135,12 @@ let useExitPaymentsheet = () => {
         //   )
         exitPaymentSheet(apiResStatus->stringifiedResStatus)
       : nativeProp.sdkState === WidgetPaymentSheet || nativeProp.sdkState === WidgetButtonSheet
-      ? hyperModule.exitWidgetPaymentsheet(rootTag, apiResStatus->stringifiedResStatus, reset)
+      ? hyperModule.exitWidgetPaymentsheet(
+        rootTag,
+        nativeProp.widgetId,
+        apiResStatus->stringifiedResStatus,
+        reset,
+      )
       : hyperModule.exitPaymentsheet(rootTag, apiResStatus->stringifiedResStatus, reset)
   }
   {exit, simplyExit}

--- a/src/hooks/useWidgetActions.res
+++ b/src/hooks/useWidgetActions.res
@@ -1,0 +1,31 @@
+open SdkTypes
+
+let useWidgetActions = (
+  ~confirmButtonData: GlobalConfirmButton.confirmButtonData,
+) => {
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+
+  React.useEffect2(() => {
+    // Only setup widget action listener for widget states
+    let shouldSetupListener = switch nativeProp.sdkState {
+    | WidgetPaymentSheet | WidgetTabSheet | WidgetButtonSheet => true
+    | _ => false
+    }
+
+    if shouldSetupListener {
+      let unsubscribe = NativeEventListener.setupWidgetActionListener(
+        ~onWidgetAction=(actionData: NativeModulesType.widgetActionData) => {
+            switch actionData.actionType {
+            | ConfirmPayment =>
+              // Trigger the confirm button press
+              confirmButtonData.handlePress(Obj.magic(()))
+            }
+        },
+      )
+
+      Some(unsubscribe)
+    } else {
+      None
+    }
+  }, (nativeProp.sdkState, confirmButtonData))
+}

--- a/src/pages/widgets/NativeEventListener.res
+++ b/src/pages/widgets/NativeEventListener.res
@@ -66,3 +66,16 @@ let setupExpressCheckoutListener = (
     onExpressCheckoutConfirm(responseFromJava)
   })
 }
+
+let setupWidgetActionListener = (~onWidgetAction: NativeModulesType.widgetActionData => unit) => {
+  setupNativeEventListener("triggerWidgetAction", var => {
+    switch var->JSON.Decode.object {
+    | Some(dict) =>
+      switch dict->NativeModulesType.widgetActionDataMapper {
+      | Some(actionData) => onWidgetAction(actionData)
+      | None => ()
+      }
+    | None => ()
+    }
+  })
+}

--- a/src/routes/GlobalConfirmButton.res
+++ b/src/routes/GlobalConfirmButton.res
@@ -20,8 +20,10 @@ let make = (~confirmButtonData) => {
   let {sheetType} = React.useContext(DynamicFieldsContext.dynamicFieldsContext)
 
   <UIUtils.RenderIf
-    condition={sheetType === DynamicFieldsSheet ||
-      (nativeProp.sdkState !== ButtonSheet && nativeProp.sdkState !== WidgetButtonSheet)}>
+    condition={!nativeProp.configuration.hideConfirmButton && (
+      sheetType === DynamicFieldsSheet ||
+        (nativeProp.sdkState !== ButtonSheet && nativeProp.sdkState !== WidgetButtonSheet)
+    )}>
     <ConfirmButton
       loading=confirmButtonData.loading
       handlePress=confirmButtonData.handlePress

--- a/src/routes/ParentPaymentSheet.res
+++ b/src/routes/ParentPaymentSheet.res
@@ -7,6 +7,7 @@ let make = () => {
   let {sheetType} = React.useContext(DynamicFieldsContext.dynamicFieldsContext)
 
   let (tabArr, elementArr, giftCardArr) = AllApiDataModifier.useAccountPaymentMethodModifier()
+
   let localeObject = GetLocale.useGetLocalObj()
 
   let (isSavedPaymentScreen, setIsSavedPaymentScreen) = React.useState(_ => true)
@@ -20,6 +21,8 @@ let make = () => {
   let setConfirmButtonData = React.useCallback1(confirmButtonData => {
     setConfirmButtonData(_ => confirmButtonData)
   }, [setConfirmButtonData])
+
+  UseWidgetActions.useWidgetActions(~confirmButtonData)
 
   <FullScreenSheetWrapper isLoading=confirmButtonData.loading>
     {switch sheetType {

--- a/src/types/NativeModulesType.res
+++ b/src/types/NativeModulesType.res
@@ -1,0 +1,33 @@
+open Utils
+
+// Widget action types that can be triggered from native side
+type widgetActionType = ConfirmPayment
+
+let widgetActionTypeToString = actionType =>
+  switch actionType {
+  | ConfirmPayment => "confirmPayment"
+  }
+
+let widgetActionTypeFromString = (str: string): option<widgetActionType> =>
+  switch str {
+  | "confirmPayment" => Some(ConfirmPayment)
+  | _ => None
+  }
+
+// Widget action data structure received from native
+type widgetActionData = {
+  actionType: widgetActionType,
+  widgetId: string,
+}
+
+let widgetActionDataMapper = (dict: Dict.t<JSON.t>): option<widgetActionData> => {
+  let actionTypeStr = dict->getString("actionType", "")
+  let widgetId = dict->getString("widgetId", "")
+
+  actionTypeStr
+  ->widgetActionTypeFromString
+  ->Option.map(actionType => {
+    actionType,
+    widgetId,
+  })
+}

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -234,6 +234,7 @@ type configurationType = {
   enablePartialLoading: bool,
   displayMergedSavedMethods: bool,
   disableBranding: bool,
+  hideConfirmButton: bool,
 }
 
 type sdkState =
@@ -312,6 +313,7 @@ type nativeProp = {
   customBackendUrl: option<string>,
   customLogUrl: option<string>,
   sessionId: string,
+  widgetId: string,
   from: string,
   configuration: configurationType,
   env: GlobalVars.envType,
@@ -786,6 +788,7 @@ let parseConfigurationDict = (configObj, from) => {
     paymentSheetHeaderText: getOptionString(configObj, "paymentSheetHeaderLabel"),
     savedPaymentScreenHeaderText: getOptionString(configObj, "savedPaymentSheetHeaderLabel"),
     displayDefaultSavedPaymentIcon: getBool(configObj, "displayDefaultSavedPaymentIcon", true),
+    hideConfirmButton: getBool(configObj, "hideConfirmButton", false),
     enablePartialLoading: getBool(configObj, "enablePartialLoading", false),
     // customer: switch customerDict {
     // | Some(obj) =>
@@ -869,7 +872,8 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
     ephemeralKey: getOptionString(dictfromNative, "ephemeralKey"),
     customBackendUrl,
     customLogUrl,
-    sessionId: "",
+    sessionId: getString(dictfromNative, "sessionId", ""),
+    widgetId: getString(dictfromNative, "widgetId", ""),
     sdkState: switch getString(dictfromNative, "type", "") {
     | "payment" => PaymentSheet
     | "tabSheet" => TabSheet


### PR DESCRIPTION
# FEAT

- This PR adds a listener for event with `name: "triggerWidgetAction"` and event-data: `ConfirmPayment`.
- This listener triggers the confirm call. 
- Response is sent using `sendMessageToNative` via `exitWidgetPaymentsheet` function.