### PR TITLE
feat: add paymentMethodsConfig support for custom payment method messages

### DIFF
--- a/src/components/common/Terms.res
+++ b/src/components/common/Terms.res
@@ -1,0 +1,67 @@
+open ReactNative
+open Style
+
+type showTerms = Auto | Always | Never
+
+@react.component
+let make = (~paymentMethod, ~paymentMethodType) => {
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+  let localeObj = GetLocale.useGetLocalObj()
+  let (accountPaymentMethodData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let paymentType =
+    accountPaymentMethodData
+    ->Option.map(accountPaymentMethods => accountPaymentMethods.payment_type)
+    ->Option.getOr(NORMAL)
+  let merchantName =
+    accountPaymentMethodData
+    ->Option.map(data => data.merchant_name)
+    ->Option.getOr(nativeProp.configuration.merchantDisplayName)
+  let customConfig = CustomPaymentMethodsConfig.useCustomPaymentMethodConfigs(
+    ~paymentMethod,
+    ~paymentMethodType,
+  )
+  let {component} = ThemebasedStyle.useThemeBasedStyle()
+
+  let customMessageConfig =
+    customConfig
+    ->Option.map(config => config.message)
+    ->Option.getOr(SdkTypes.defaultPaymentMethodMessage)
+
+  let cardTermsValue = localeObj.cardTermsPart1 ++ merchantName ++ localeObj.cardTermsPart2
+
+  let paymentMethodTermsDefaults = switch paymentMethod {
+  | "bank_debit" =>
+    switch paymentMethodType {
+    | "sepa" => (localeObj.sepaDebitTermsPart1 ++ localeObj.sepaDebitTermsPart2 ++ localeObj.sepaDebitTermsPart3, Auto)
+    | "becs" => (localeObj.becsDebitTerms, Auto)
+    | "ach" => (localeObj.achBankDebitTermsPart1 ++ merchantName ++ localeObj.achBankDebitTermsPart2, Auto)
+    | _ => ("", Never)
+    }
+  | "card" =>
+    switch paymentType {
+    | NEW_MANDATE | SETUP_MANDATE => (cardTermsValue, Auto)
+    | _ => ("", Never)
+    }
+  | _ => ("", Never)
+  }
+
+  let (termsText, showTerm) = switch customMessageConfig.displayMode {
+  | DefaultSdkMessage => paymentMethodTermsDefaults
+  | CustomMessage => {
+      let customMessage = customMessageConfig.value->Option.getOr("")->String.trim
+      (customMessage, customMessage->String.length > 0 ? Always : Never)
+    }
+  | Hidden => ("", Never)
+  }
+
+  <UIUtils.RenderIf condition={showTerm == Auto || showTerm == Always}>
+    <Text
+      style={s({
+        color: component.color,
+        fontSize: 12.,
+        marginVertical: 8.->dp,
+      })}>
+      {React.string(termsText)}
+    </Text>
+  </UIUtils.RenderIf>
+}

--- a/src/components/dynamic/DynamicComponent.res
+++ b/src/components/dynamic/DynamicComponent.res
@@ -226,6 +226,8 @@ let make = (~setConfirmButtonData) => {
       isCardPayment
       enabledCardSchemes
       accessible=true
+      paymentMethod=payment_method_str
+      paymentMethodType=payment_method_type
     />
   </ReactNative.View>
 }

--- a/src/components/dynamic/DynamicFields.res
+++ b/src/components/dynamic/DynamicFields.res
@@ -9,6 +9,8 @@ let make = (
   ~isGiftCardPayment=false,
   ~enabledCardSchemes=[],
   ~accessible: bool,
+  ~paymentMethod="",
+  ~paymentMethodType="",
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   let (accountPaymentMethodData, customerPaymentMethodData, _) = React.useContext(
@@ -84,6 +86,9 @@ let make = (
         <Space />
       </UIUtils.RenderIf>
       <RedirectionText />
+    </UIUtils.RenderIf>
+    <UIUtils.RenderIf condition={!isGiftCardPayment && paymentMethod->String.length > 0}>
+      <Terms paymentMethod paymentMethodType />
     </UIUtils.RenderIf>
   </>
 }

--- a/src/components/dynamic/TabElement.res
+++ b/src/components/dynamic/TabElement.res
@@ -92,5 +92,7 @@ let make = (
     isCardPayment
     enabledCardSchemes
     accessible
+    paymentMethod=paymentMethodData.payment_method_str
+    paymentMethodType=paymentMethodData.payment_method_type
   />
 }

--- a/src/hooks/CustomPaymentMethodsConfig.res
+++ b/src/hooks/CustomPaymentMethodsConfig.res
@@ -1,0 +1,16 @@
+let useCustomPaymentMethodConfigs = (~paymentMethod, ~paymentMethodType) => {
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+  let paymentMethodsConfig = nativeProp.configuration.paymentMethodsConfig
+  let allowedPmTypeForCardPayment = ["debit", "credit"]
+  React.useMemo3(() => {
+    paymentMethodsConfig
+    ->Array.filter(paymentMethodConfig => paymentMethodConfig.paymentMethod == paymentMethod)
+    ->Array.flatMap(paymentMethodConfig => paymentMethodConfig.paymentMethodTypes)
+    ->Array.filter(paymentMethodTypeConfig =>
+      paymentMethod == "card"
+        ? allowedPmTypeForCardPayment->Array.includes(paymentMethodTypeConfig.paymentMethodType)
+        : paymentMethodTypeConfig.paymentMethodType == paymentMethodType
+    )
+    ->Array.get(0)
+  }, (paymentMethod, paymentMethodType, paymentMethodsConfig))
+}

--- a/src/hooks/ThemebasedStyle.res
+++ b/src/hooks/ThemebasedStyle.res
@@ -12,6 +12,7 @@ type componentConfig = {
   dividerColor: ReactNative.Color.t,
   color: ReactNative.Color.t,
 }
+
 type statusColor = {
   green: statusColorConfig,
   orange: statusColorConfig,

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -581,5 +581,6 @@ let make = (
           <Space height=5. />
         </View>
       : React.null}
+    <Terms paymentMethod="card" paymentMethodType="debit" />
   </ErrorBoundary>
 }

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -214,6 +214,25 @@ type placeholder = {
   cvv: string,
 }
 
+type messageDisplayMode = DefaultSdkMessage | CustomMessage | Hidden
+
+type paymentMethodMessage = {
+  value: option<string>,
+  displayMode: messageDisplayMode,
+}
+
+type paymentMethodTypeConfig = {
+  paymentMethodType: string,
+  message: paymentMethodMessage,
+}
+
+type paymentMethodConfig = {
+  paymentMethod: string,
+  paymentMethodTypes: array<paymentMethodTypeConfig>,
+}
+
+type paymentMethodsConfig = array<paymentMethodConfig>
+
 type configurationType = {
   allowsDelayedPaymentMethods: bool,
   appearance: appearance,
@@ -234,6 +253,7 @@ type configurationType = {
   enablePartialLoading: bool,
   displayMergedSavedMethods: bool,
   disableBranding: bool,
+  paymentMethodsConfig: paymentMethodsConfig,
 }
 
 type sdkState =
@@ -719,6 +739,61 @@ let getPrimaryColor = (colors, ~theme=Default) =>
     }
   }
 
+let defaultPaymentMethodMessage = {
+  value: None,
+  displayMode: DefaultSdkMessage,
+}
+
+let getMessageDisplayMode = str => {
+  switch str {
+  | "default_sdk_message" => DefaultSdkMessage
+  | "custom_message" => CustomMessage
+  | "hidden" => Hidden
+  | _ => DefaultSdkMessage
+  }
+}
+
+let getPaymentMethodMessage = dict => {
+  let messageDict = getObj(dict, "message", Dict.make())
+  if messageDict->Dict.toArray->Array.length > 0 {
+    let value = getOptionString(messageDict, "value")
+    let displayMode = switch messageDict->Dict.get("displayMode") {
+    | Some(_) => getMessageDisplayMode(getString(messageDict, "displayMode", "default_sdk_message"))
+    | None => switch value {
+      | Some(_) => CustomMessage
+      | None => DefaultSdkMessage
+      }
+    }
+    {value, displayMode}
+  } else {
+    defaultPaymentMethodMessage
+  }
+}
+
+let getPaymentMethodTypeConfig = dict => {
+  {
+    paymentMethodType: getString(dict, "paymentMethodType", ""),
+    message: getPaymentMethodMessage(dict),
+  }
+}
+
+let getPaymentMethodConfig = dict => {
+  {
+    paymentMethod: getString(dict, "paymentMethod", ""),
+    paymentMethodTypes: dict
+    ->getArray("paymentMethodTypes")
+    ->Belt.Array.keepMap(JSON.Decode.object)
+    ->Array.map(getPaymentMethodTypeConfig),
+  }
+}
+
+let getPaymentMethodsConfig = (dict, str) => {
+  dict
+  ->getArray(str)
+  ->Belt.Array.keepMap(JSON.Decode.object)
+  ->Array.map(getPaymentMethodConfig)
+}
+
 let parseConfigurationDict = (configObj, from) => {
   let shippingDetailsDict =
     configObj->Dict.get("shippingDetails")->Option.flatMap(JSON.Decode.object)
@@ -836,6 +911,7 @@ let parseConfigurationDict = (configObj, from) => {
     },
     displayMergedSavedMethods: getBool(configObj, "displayMergedSavedMethods", false),
     disableBranding: getBool(configObj, "disableBranding", false),
+    paymentMethodsConfig: getPaymentMethodsConfig(configObj, "paymentMethodsConfig"),
   }
   configuration
 }


### PR DESCRIPTION
## Summary

- Add support for `paymentMethodsConfig` prop to allow merchants to display custom messages for different payment methods
- This mirrors the implementation in hyperswitch-web for consistency across platforms

## Changes

- **Types (SdkTypes.res)**: Added types for `paymentMethodsConfig`, `paymentMethodConfig`, `paymentMethodTypeConfig`, `paymentMethodMessage`, and `messageDisplayMode`
- **Parsing**: Added functions to deserialize `paymentMethodsConfig` from native props
- **Hook (CustomPaymentMethodsConfig.res)**: Created new hook to retrieve config by payment method and payment method type
- **SavedPaymentSheet**: Updated to display custom message based on `displayMode` (CustomMessage, DefaultSdkMessage, Hidden)

## Usage

Merchants can pass:
```json
{
  "paymentMethodsConfig": [
    {
      "paymentMethod": "card",
      "paymentMethodTypes": [
        {
          "paymentMethodType": "debit",
          "message": {
            "value": "Custom message here",
            "displayMode": "custom_message"
          }
        }
      ]
    }
  ]
}
```

<img width="445" height="822" alt="Screenshot 2026-03-29 at 3 59 23 AM" src="https://github.com/user-attachments/assets/fa26b2b3-5dfc-450a-9832-ba48d5760979" />
<img width="417" height="841" alt="Screenshot 2026-03-29 at 4 00 30 AM" src="https://github.com/user-attachments/assets/c1c864cc-cb9d-49e8-a047-732067cb9bff" />

