### PR TITLE
feat: add hideCardExpiryForSavedCards config for compact saved card view

### DIFF
--- a/src/pages/payment/SavedPaymentMethod.res
+++ b/src/pages/payment/SavedPaymentMethod.res
@@ -29,6 +29,8 @@ module CVVComponent = {
       None
     }, [errorMsgText])
 
+    let cvcWidth = 100.->dp
+
     <View
       style={s({
         display: #flex,
@@ -50,7 +52,7 @@ module CVVComponent = {
         fontSize=12.
         keyboardType=#"number-pad"
         enableCrossIcon=false
-        width={100.->dp}
+        width=cvcWidth
         height=40.
         isValid={isCvcValid}
         onFocus={() => {
@@ -66,6 +68,7 @@ module CVVComponent = {
             ? <Icon name="cvvfilled" height=35. width=35. fill="black" />
             : <Icon name="cvvempty" height=35. width=35. fill="black" />
         })
+        style={isInline ? s({width: cvcWidth}) : s({width: 100.->pct})}
       />
     </View>
   }
@@ -221,23 +224,18 @@ module PaymentMethodListView = {
             }
           : React.null}
         {hideCardExpiryForSavedCards && showCvv
-          ? <View style={s({marginStart: auto})}>
-              <CVVComponent
-                savedCardCvv
-                setSavedCardCvv
-                cardScheme
-                isInline=true
-                onErrorTextChange={err => setCvcError(_ => err)}
-              />
-            </View>
+          ? <CVVComponent
+              savedCardCvv
+              setSavedCardCvv
+              cardScheme
+              isInline=true
+              onErrorTextChange={err => setCvcError(_ => err)}
+            />
           : React.null}
       </View>
       {!hideCardExpiryForSavedCards && showCvv
         ? <CVVComponent
-            savedCardCvv
-            setSavedCardCvv
-            cardScheme
-            onErrorTextChange={err => setCvcError(_ => err)}
+            savedCardCvv setSavedCardCvv cardScheme onErrorTextChange={err => setCvcError(_ => err)}
           />
         : React.null}
       {showCvv && cvcError->Option.isSome

--- a/src/pages/payment/SavedPaymentMethod.res
+++ b/src/pages/payment/SavedPaymentMethod.res
@@ -3,7 +3,13 @@ open Style
 
 module CVVComponent = {
   @react.component
-  let make = (~savedCardCvv, ~setSavedCardCvv, ~cardScheme) => {
+  let make = (
+    ~savedCardCvv,
+    ~setSavedCardCvv,
+    ~cardScheme,
+    ~isInline=false,
+    ~onErrorTextChange: option<string> => unit=_ => (),
+  ) => {
     let {component, dangerColor} = ThemebasedStyle.useThemeBasedStyle()
 
     let (isCvcFocus, setIsCvcFocus) = React.useState(_ => false)
@@ -18,56 +24,50 @@ module CVVComponent = {
     let errorMsgText = !isCvcValid ? Some(localeObject.inCompleteCVCErrorText) : None
     let onCvvChange = cvv => setSavedCardCvv(_ => Some(Validation.formatCVCNumber(cvv, cardScheme)))
 
-    <>
-      <View
-        style={s({
-          display: #flex,
-          flexDirection: #row,
-          alignItems: #center,
-          paddingHorizontal: 47.5->dp,
-          marginTop: 10.->dp,
-        })}>
-        <View style={s({width: {50.->dp}})}>
-          <TextWrapper text="CVC:" textType={ModalText} />
-        </View>
-        <CustomInput
-          state={savedCardCvv->Option.getOr("")}
-          setState={onCvvChange}
-          placeholder="123"
-          animateLabel="CVC"
-          fontSize=12.
-          keyboardType=#"number-pad"
-          enableCrossIcon=false
-          width={100.->dp}
-          height=40.
-          isValid={isCvcValid}
-          onFocus={() => {
-            setIsCvcFocus(_ => true)
-          }}
-          onBlur={() => {
-            setIsCvcFocus(_ => false)
-          }}
-          secureTextEntry=true
-          textColor={isCvcValid ? component.color : dangerColor}
-          iconRight=CustomIcon({
-            Validation.checkCardCVC(savedCardCvv->Option.getOr(""), cardScheme)
-              ? <Icon name="cvvfilled" height=35. width=35. fill="black" />
-              : <Icon name="cvvempty" height=35. width=35. fill="black" />
-          })
-        />
-      </View>
-      {errorMsgText->Option.isSome
-        ? <View
-            style={s({
-              display: #flex,
-              flexDirection: #row,
-              alignItems: #center,
-              paddingLeft: 100.->dp,
-            })}>
-            <ErrorText text=errorMsgText />
+    React.useEffect1(() => {
+      onErrorTextChange(errorMsgText)
+      None
+    }, [errorMsgText])
+
+    <View
+      style={s({
+        display: #flex,
+        flexDirection: #row,
+        alignItems: #center,
+        paddingHorizontal: isInline ? 0.->dp : 47.5->dp,
+        marginTop: isInline ? 0.->dp : 10.->dp,
+      })}>
+      {!isInline
+        ? <View style={s({width: {50.->dp}})}>
+            <TextWrapper text="CVC:" textType={ModalText} />
           </View>
         : React.null}
-    </>
+      <CustomInput
+        state={savedCardCvv->Option.getOr("")}
+        setState={onCvvChange}
+        placeholder={isInline ? "CVC" : "123"}
+        animateLabel="CVC"
+        fontSize=12.
+        keyboardType=#"number-pad"
+        enableCrossIcon=false
+        width={100.->dp}
+        height=40.
+        isValid={isCvcValid}
+        onFocus={() => {
+          setIsCvcFocus(_ => true)
+        }}
+        onBlur={() => {
+          setIsCvcFocus(_ => false)
+        }}
+        secureTextEntry=true
+        textColor={isCvcValid ? component.color : dangerColor}
+        iconRight=CustomIcon({
+          Validation.checkCardCVC(savedCardCvv->Option.getOr(""), cardScheme)
+            ? <Icon name="cvvfilled" height=35. width=35. fill="black" />
+            : <Icon name="cvvempty" height=35. width=35. fill="black" />
+        })
+      />
+    </View>
   }
 }
 module PMWithNickNameComponent = {
@@ -165,6 +165,18 @@ module PaymentMethodListView = {
   ) => {
     let localeObj = GetLocale.useGetLocalObj()
     let {primaryColor, component} = ThemebasedStyle.useThemeBasedStyle()
+    let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+    let hideCardExpiryForSavedCards = nativeProp.configuration.hideCardExpiryForSavedCards
+
+    let showCvv =
+      isPaymentMethodSelected &&
+      savedPaymentMethod.payment_method === CARD &&
+      savedPaymentMethod.requires_cvv
+
+    let cardScheme =
+      savedPaymentMethod.card->Option.map(card => card.card_network)->Option.getOr("")
+
+    let (cvcError, setCvcError) = React.useState(_ => None)
 
     <CustomPressable
       onPress={_ => {
@@ -183,7 +195,8 @@ module PaymentMethodListView = {
       <View
         style={s({
           flexDirection: #row,
-          flexWrap: #wrap,
+          flexWrap: hideCardExpiryForSavedCards ? #nowrap : #wrap,
+          width: 100.->pct,
           alignItems: #center,
           justifyContent: #"space-between",
           paddingHorizontal: 12.->dp,
@@ -194,28 +207,49 @@ module PaymentMethodListView = {
           <Space />
           <PMWithNickNameComponent savedPaymentMethod />
         </View>
-        {switch savedPaymentMethod.card {
-        | Some(card) =>
-          <TextWrapper
-            text={`${localeObj.cardExpiresText} ${card.expiry_month}/${card.expiry_year->String.sliceToEnd(
-                ~start=-2,
-              )}`}
-            textType={ModalTextLight}
-            overrideStyle={Some(s({marginLeft: auto}))}
-          />
-        | None => React.null
-        }}
+        {!hideCardExpiryForSavedCards
+          ? switch savedPaymentMethod.card {
+            | Some(card) =>
+              <TextWrapper
+                text={`${localeObj.cardExpiresText} ${card.expiry_month}/${card.expiry_year->String.sliceToEnd(
+                    ~start=-2,
+                  )}`}
+                textType={ModalTextLight}
+                overrideStyle={Some(s({marginStart: auto}))}
+              />
+            | None => React.null
+            }
+          : React.null}
+        {hideCardExpiryForSavedCards && showCvv
+          ? <View style={s({marginStart: auto})}>
+              <CVVComponent
+                savedCardCvv
+                setSavedCardCvv
+                cardScheme
+                isInline=true
+                onErrorTextChange={err => setCvcError(_ => err)}
+              />
+            </View>
+          : React.null}
       </View>
-      {isPaymentMethodSelected &&
-      savedPaymentMethod.payment_method === CARD &&
-      savedPaymentMethod.requires_cvv
+      {!hideCardExpiryForSavedCards && showCvv
         ? <CVVComponent
             savedCardCvv
             setSavedCardCvv
-            cardScheme={savedPaymentMethod.card
-            ->Option.map(card => card.card_network)
-            ->Option.getOr("")}
+            cardScheme
+            onErrorTextChange={err => setCvcError(_ => err)}
           />
+        : React.null}
+      {showCvv && cvcError->Option.isSome
+        ? <View
+            style={s({
+              display: #flex,
+              flexDirection: #row,
+              alignItems: #center,
+              paddingStart: 47.5->dp,
+            })}>
+            <ErrorText text=cvcError />
+          </View>
         : React.null}
     </CustomPressable>
   }

--- a/src/pages/widgets/ExpressCheckoutWidget.res
+++ b/src/pages/widgets/ExpressCheckoutWidget.res
@@ -302,10 +302,16 @@ let make = () => {
     None
   }, [confirm])
 
+  let hideCardExpiryForSavedCards = nativeProp.configuration.hideCardExpiryForSavedCards
+  let (cvcError, setCvcError) = React.useState(_ => None)
+
   React.useEffect1(_ => {
     let widgetHeight = {
       switch firstPaymentMethod {
-      | Some(pm) => pm.requires_cvv ? 290 : 150
+      | Some(pm) =>
+        pm.requires_cvv
+          ? hideCardExpiryForSavedCards ? 200 : 290
+          : 150
       | _ => 150
       }
     }
@@ -329,7 +335,7 @@ let make = () => {
       style={s({
         flex: 1.,
         flexDirection: #row,
-        flexWrap: #wrap,
+        flexWrap: hideCardExpiryForSavedCards ? #nowrap : #wrap,
         width: 100.->pct,
         paddingHorizontal: 15.->dp,
         alignItems: #center,
@@ -339,28 +345,68 @@ let make = () => {
       | Some(_pmDetails) => React.null //<SavedPaymentMethod.PMWithNickNameComponent savedPaymentMethod={pmDetails} />
       | None => React.null
       }}
-      {switch firstPaymentMethod {
-      | Some(obj) =>
-        switch obj.card {
-        | Some(card) =>
-          <TextWrapper
-            text={`${localeObj.cardExpiresText} ${card.expiry_month}/${card.expiry_year->String.sliceToEnd(
-                ~start=-2,
-              )}`}
-            textType={ModalTextLight}
-          />
-        | None => React.null
-        }
-
-      | None => React.null
-      }}
+      {!hideCardExpiryForSavedCards
+        ? switch firstPaymentMethod {
+          | Some(obj) =>
+            switch obj.card {
+            | Some(card) =>
+              <TextWrapper
+                text={`${localeObj.cardExpiresText} ${card.expiry_month}/${card.expiry_year->String.sliceToEnd(
+                    ~start=-2,
+                  )}`}
+                textType={ModalTextLight}
+              />
+            | None => React.null
+            }
+          | None => React.null
+          }
+        : React.null}
+      {hideCardExpiryForSavedCards
+        ? switch firstPaymentMethod {
+          | Some(pm) =>
+            pm.requires_cvv
+              ? <View style={s({marginStart: auto})}>
+                  <SavedPaymentMethod.CVVComponent
+                    savedCardCvv
+                    setSavedCardCvv
+                    cardScheme
+                    isInline=true
+                    onErrorTextChange={err => setCvcError(_ => err)}
+                  />
+                </View>
+              : React.null
+          | _ => React.null
+          }
+        : React.null}
     </View>
+    {!hideCardExpiryForSavedCards
+      ? switch firstPaymentMethod {
+        | Some(pm) =>
+          pm.requires_cvv
+            ? <SavedPaymentMethod.CVVComponent
+                savedCardCvv
+                setSavedCardCvv
+                cardScheme
+                onErrorTextChange={err => setCvcError(_ => err)}
+              />
+            : React.null
+        | _ => React.null
+        }
+      : React.null}
     {switch firstPaymentMethod {
-    | Some(pm) =>
-      pm.requires_cvv
-        ? <SavedPaymentMethod.CVVComponent savedCardCvv setSavedCardCvv cardScheme />
-        : React.null
-    | _ => React.null
-    }}
+      | Some(pm) => pm.requires_cvv
+      | _ => false
+      } &&
+      cvcError->Option.isSome
+      ? <View
+          style={s({
+            display: #flex,
+            flexDirection: #row,
+            alignItems: #center,
+            paddingStart: 15.->dp,
+          })}>
+          <ErrorText text=cvcError />
+        </View>
+      : React.null}
   </View>
 }

--- a/src/pages/widgets/ExpressCheckoutWidget.res
+++ b/src/pages/widgets/ExpressCheckoutWidget.res
@@ -365,15 +365,13 @@ let make = () => {
         ? switch firstPaymentMethod {
           | Some(pm) =>
             pm.requires_cvv
-              ? <View style={s({marginStart: auto})}>
-                  <SavedPaymentMethod.CVVComponent
-                    savedCardCvv
-                    setSavedCardCvv
-                    cardScheme
-                    isInline=true
-                    onErrorTextChange={err => setCvcError(_ => err)}
-                  />
-                </View>
+              ? <SavedPaymentMethod.CVVComponent
+                  savedCardCvv
+                  setSavedCardCvv
+                  cardScheme
+                  isInline=true
+                  onErrorTextChange={err => setCvcError(_ => err)}
+                />
               : React.null
           | _ => React.null
           }

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -234,6 +234,7 @@ type configurationType = {
   enablePartialLoading: bool,
   displayMergedSavedMethods: bool,
   disableBranding: bool,
+  hideCardExpiryForSavedCards: bool,
 }
 
 type sdkState =
@@ -836,6 +837,7 @@ let parseConfigurationDict = (configObj, from) => {
     },
     displayMergedSavedMethods: getBool(configObj, "displayMergedSavedMethods", false),
     disableBranding: getBool(configObj, "disableBranding", false),
+    hideCardExpiryForSavedCards: getBool(configObj, "hideCardExpiryForSavedCards", false),
   }
   configuration
 }


### PR DESCRIPTION
## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Add a new `hideCardExpiryForSavedCards` boolean config that enables a compact saved card view where the expiry date is hidden and the CVC input is rendered inline on the same row as the card details.
This is the React Native SDK counterpart of juspay/hyperswitch-web#1443, which adds `hideCardExpiry` under `savedMethodCustomization` in the web SDK. In the client-core SDK, config is a flat record (no nested `savedMethodCustomization`), so the field is named `hideCardExpiryForSavedCards` for clarity.

## Changes

- **`SdkTypes.res`**: Added `hideCardExpiryForSavedCards: bool` to `configurationType` (default: `false`)
- **`SavedPaymentMethod.res`**:
  - `CVVComponent` extended with `~isInline` and `~onErrorTextChange` props for inline rendering
  - When inline: "CVC:" label hidden, placeholder changed to "CVC", error text delegated to parent via callback
  - `PaymentMethodListView` conditionally hides expiry text and renders CVC inline in the card row
  - Fixed pre-existing error text misalignment (`paddingLeft: 100dp` → `paddingStart: 47.5dp`)
  - Fixed RTL: `marginLeft: auto` → `marginStart: auto`
- **`ExpressCheckoutWidget.res`**: Same conditional expiry/CVC rendering for the express checkout widget

## Behavior

| Config | Expiry text | CVC position |
|--------|------------|-------------|
| `false` (default) | Shown | Below card row |
| `true` | Hidden | Inline in card row |

## How did you test it?

Manual testing in React Native Web demo app.


https://github.com/user-attachments/assets/5bee02fe-bda6-4d00-832a-06d6c3bcf1f2


## Checklist

- [x] I ran `yarn re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible