### PR TITLE
feat: add standalone Apple Pay widget component

### DIFF
--- a/src/pages/widgets/CustomWidget.res
+++ b/src/pages/widgets/CustomWidget.res
@@ -10,71 +10,314 @@ module WidgetError = {
 }
 
 @react.component
-let make = (~walletType as _: SdkTypes.payment_method_type_wallet) => {
-  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  // let (allApiData, _) = React.useContext(AllApiDataContext.allApiDataContext)
-  let (button, _setButton) = React.useState(_ => None)
+let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
+  let (nativeProp, setNativeProp) = React.useContext(NativePropContext.nativePropContext)
+  let (_, _, sessionTokenData) = React.useContext(
+    AllApiDataContextNew.allApiDataContext,
+  )
+  let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
+  let {getRequiredFieldsForButton, setInitialValueCountry} = React.useContext(
+    DynamicFieldsContext.dynamicFieldsContext,
+  )
 
-  // React.useEffect1(() => {
-  //   if nativeProp.publishableKey == "" {
-  //     setLoading(ProcessingPayments)
-  //   } else {
-  //     // setButton(_ =>
-  //     //   PMListModifier.widgetModifier(
-  //     //     allApiData.paymentMethodList,
-  //     //     allApiData.sessions,
-  //     //     walletType,
-  //     //     nativeProp.hyperParams.confirm,
-  //     //   )
-  //     // )
-  //     ()
-  //   }
+  let handleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
+  let fetchAndRedirect = AllPaymentHooks.useRedirectHook()
+  let handleWalletPayments = ButtonHook.useProcessPayButtonResult()
+  let showAlert = AlertHook.useAlerts()
+  let logger = LoggerHook.useLoggerHook()
+  let {
+    applePayButtonColor,
+    buttonBorderRadius,
+    primaryButtonHeight,
+  } = ThemebasedStyle.useThemeBasedStyle()
 
-  //   let handleWidgetEvent = (responseFromJava: NativeEventListener.widgetResponse) => {
-  //     if (
-  //       walletType ==
-  //         switch responseFromJava.paymentMethodType {
-  //         | "google_pay" => GOOGLE_PAY
-  //         | "paypal" => PAYPAL
-  //         | _ => NONE
-  //         }
-  //     ) {
-  //       setNativeProp({
-  //         ...nativeProp,
-  //         publishableKey: responseFromJava.publishableKey,
-  //         clientSecret: responseFromJava.clientSecret,
-  //         hyperParams: {
-  //           ...nativeProp.hyperParams,
-  //           confirm: responseFromJava.confirm,
-  //         },
-  //         configuration: {
-  //           ...nativeProp.configuration,
-  //           appearance: {
-  //             ...nativeProp.configuration.appearance,
-  //             googlePay: {
-  //               buttonType: PLAIN,
-  //               buttonStyle: None,
-  //             },
-  //           },
-  //         },
-  //       })
-  //     }
-  //   }
+  // Keep a ref to the latest nativeProp so callbacks always read current credentials.
+  let nativePropRef = React.useRef(nativeProp)
+  React.useEffect1(() => {
+    nativePropRef.current = nativeProp
+    None
+  }, [nativeProp])
 
-  //   let cleanup = NativeEventListener.setupWidgetEventListener(
-  //     ~onWidgetEvent=handleWidgetEvent,
-  //     ~walletType,
-  //   )
+  // Extract session token matching walletType
+  let sessionObject =
+    sessionTokenData
+    ->Option.flatMap(sessions => sessions->Array.find(item => item.wallet_name == walletType))
+    ->Option.getOr(SessionsType.defaultToken)
 
-  //   Some(cleanup)
-  // }, [allApiData.sessions])
+  // Build a payment_method_type record for Apple Pay
+  let paymentMethodData: AccountPaymentMethodType.payment_method_type = {
+    payment_method: WALLET,
+    payment_method_str: "wallet",
+    payment_method_type: "apple_pay",
+    payment_method_type_wallet: APPLE_PAY,
+    card_networks: [],
+    bank_names: [],
+    payment_experience: [],
+    required_fields: Dict.make(),
+  }
+
+  let errorCallback = (~errorMessage: PaymentConfirmTypes.error, ~closeSDK, ()) => {
+    setLoading(FillingDetails)
+    handleSuccessFailure(~apiResStatus=errorMessage, ~closeSDK, ())
+  }
+
+  let responseCallback = (~paymentStatus: LoadingContext.sdkPaymentState, ~status) => {
+    switch paymentStatus {
+    | PaymentSuccess => {
+        setLoading(PaymentSuccess)
+        setTimeout(() => {
+          handleSuccessFailure(~apiResStatus=status, ())
+        }, 300)->ignore
+      }
+    | _ => handleSuccessFailure(~apiResStatus=status, ())
+    }
+  }
+
+  // Reads nativePropRef.current to avoid stale closure over nativeProp.
+  let processRequest = (walletDict, email) => {
+    let currentNativeProp = nativePropRef.current
+
+    // Guard: don't confirm with empty credentials
+    if currentNativeProp.clientSecret == "" {
+      setLoading(FillingDetails)
+      showAlert(~errorType="error", ~message="Payment session not initialized")
+    } else {
+      let payment_method_data =
+        walletDict->Option.map(dict =>
+          [("wallet", [("apple_pay", dict->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object)]
+          ->Dict.fromArray
+          ->JSON.Encode.object
+        )
+
+      let body: PaymentConfirmTypes.redirectType = {
+        client_secret: currentNativeProp.clientSecret,
+        return_url: ?Utils.getReturnUrl(~appId=currentNativeProp.hyperParams.appId),
+        ?email,
+        payment_method: "wallet",
+        payment_method_type: "apple_pay",
+        ?payment_method_data,
+        customer_acceptance: ?(
+          Some({
+            acceptance_type: "online",
+            accepted_at: Date.now()->Date.fromTime->Date.toISOString,
+            online: {
+              user_agent: ?currentNativeProp.hyperParams.userAgent,
+            },
+          })
+        ),
+        browser_info: {
+          user_agent: ?currentNativeProp.hyperParams.userAgent,
+          device_model: ?currentNativeProp.hyperParams.device_model,
+          os_type: ?currentNativeProp.hyperParams.os_type,
+          os_version: ?currentNativeProp.hyperParams.os_version,
+        },
+      }
+
+      fetchAndRedirect(
+        ~body=body->JSON.stringifyAny->Option.getOr(""),
+        ~publishableKey=currentNativeProp.publishableKey,
+        ~clientSecret=currentNativeProp.clientSecret,
+        ~errorCallback,
+        ~responseCallback,
+        ~paymentMethod="apple_pay",
+        (),
+      )
+    }
+  }
+
+  let processWalletData = (
+    walletDict,
+    ~billingAddress=?,
+    ~shippingAddress=?,
+  ) => {
+    let (isFieldsMissing, initialValues, defaultCountry) = getRequiredFieldsForButton(
+      paymentMethodData,
+      walletDict,
+      billingAddress,
+      shippingAddress,
+      false,
+      None,
+    )
+    setInitialValueCountry(defaultCountry)
+
+    if !isFieldsMissing {
+      let email = initialValues->Dict.get("email")->Option.flatMap(JSON.Decode.string)
+      processRequest(
+        Some(walletDict),
+        email,
+      )
+    } else {
+      setLoading(FillingDetails)
+    }
+  }
+
+  let confirmApplePay = (var: dict<JSON.t>) => {
+    logger(
+      ~logType=DEBUG,
+      ~value="apple_pay",
+      ~category=USER_EVENT,
+      ~paymentMethod="apple_pay",
+      ~eventName=APPLE_PAY_CALLBACK_FROM_NATIVE,
+      (),
+    )
+
+    let status = handleWalletPayments(APPLE_PAY, var)
+
+    switch status {
+    | Success(walletData, billingAddress, shippingAddress) =>
+      processWalletData(walletData, ~billingAddress?, ~shippingAddress?)
+    | Cancelled =>
+      setLoading(FillingDetails)
+      showAlert(~errorType="warning", ~message="Cancelled")
+    | Simulated =>
+      setTimeout(() => {
+        setLoading(FillingDetails)
+        showAlert(
+          ~errorType="warning",
+          ~message="Apple Pay is not supported in Simulated Environment",
+        )
+      }, 2000)->ignore
+    | Failed(error_message) =>
+      setLoading(FillingDetails)
+      showAlert(~errorType="error", ~message=error_message)
+    }
+  }
+
+  let pressHandler = () => {
+    setLoading(ProcessingPayments)
+    logger(
+      ~logType=INFO,
+      ~value="apple_pay",
+      ~category=USER_EVENT,
+      ~paymentMethod="apple_pay",
+      ~eventName=PAYMENT_METHOD_CHANGED,
+      (),
+    )
+
+    if (
+      sessionObject.session_token_data == JSON.Encode.null ||
+        sessionObject.payment_request_data == JSON.Encode.null
+    ) {
+      setLoading(FillingDetails)
+      showAlert(~errorType="warning", ~message="Waiting for Sessions API")
+    } else {
+      logger(
+        ~logType=DEBUG,
+        ~value="apple_pay",
+        ~category=USER_EVENT,
+        ~paymentMethod="apple_pay",
+        ~eventName=APPLE_PAY_STARTED_FROM_JS,
+        (),
+      )
+
+      let timerId = setTimeout(() => {
+        setLoading(FillingDetails)
+        showAlert(~errorType="warning", ~message="Apple Pay Error, Please try again")
+        logger(
+          ~logType=DEBUG,
+          ~value="apple_pay",
+          ~category=USER_EVENT,
+          ~paymentMethod="apple_pay",
+          ~eventName=APPLE_PAY_PRESENT_FAIL_FROM_NATIVE,
+          (),
+        )
+      }, 5000)
+
+      HyperModule.launchApplePay(
+        [
+          ("session_token_data", sessionObject.session_token_data),
+          ("payment_request_data", sessionObject.payment_request_data),
+        ]
+        ->Dict.fromArray
+        ->JSON.Encode.object
+        ->JSON.stringify,
+        confirmApplePay,
+        _ => {
+          logger(
+            ~logType=DEBUG,
+            ~value="apple_pay",
+            ~category=USER_EVENT,
+            ~paymentMethod="apple_pay",
+            ~eventName=APPLE_PAY_BRIDGE_SUCCESS,
+            (),
+          )
+        },
+        _ => {
+          clearTimeout(timerId)
+        },
+      )
+    }
+  }
+
+  // Register event listener for Apple Pay data from native.
+  // Re-registers when publishableKey changes so confirmApplePay reads fresh nativeProp.
+  React.useEffect1(() => {
+    switch walletType {
+    | APPLE_PAY => Window.registerEventListener("applePayData", confirmApplePay)
+    | _ => ()
+    }
+    None
+  }, [nativeProp.publishableKey])
+
+  // Widget communication: listen for native events and update nativeProp
+  React.useEffect1(() => {
+    if nativeProp.publishableKey == "" {
+      setLoading(ProcessingPayments)
+    }
+
+    let handleWidgetEvent = (responseFromJava: NativeEventListener.widgetResponse) => {
+      if (
+        walletType ==
+          switch responseFromJava.paymentMethodType {
+          | "apple_pay" => SdkTypes.APPLE_PAY
+          | "google_pay" => GOOGLE_PAY
+          | "paypal" => PAYPAL
+          | _ => NONE
+          }
+      ) {
+        setNativeProp({
+          ...nativeProp,
+          publishableKey: responseFromJava.publishableKey,
+          clientSecret: responseFromJava.clientSecret,
+          hyperParams: {
+            ...nativeProp.hyperParams,
+            confirm: responseFromJava.confirm,
+          },
+        })
+        setLoading(FillingDetails)
+        // Note: NOT auto-confirming for Apple Pay — Apple requires a user gesture
+        // to present the payment sheet (Apple Human Interface Guidelines).
+      }
+    }
+
+    let cleanup = NativeEventListener.setupWidgetEventListener(
+      ~onWidgetEvent=handleWidgetEvent,
+      ~walletType,
+    )
+
+    Some(cleanup)
+  }, [nativeProp.publishableKey])
+
+  // Report widget height
+  React.useEffect0(() => {
+    HyperModule.updateWidgetHeight(45)
+    None
+  })
 
   <ErrorBoundary level={FallBackScreen.Widget} rootTag=nativeProp.rootTag>
     <View
       style={s({flex: 1., width: 100.->pct, maxHeight: 45.->dp, backgroundColor: "transparent"})}>
-      {switch button {
-      | Some(component) => component === React.null ? <WidgetError /> : component
-      | None => <LoadingOverlay />
+      {switch walletType {
+      | APPLE_PAY =>
+        <TouchableOpacity onPress={_ => pressHandler()} activeOpacity=0.8>
+          <ApplePayButtonView
+            style={s({height: primaryButtonHeight->dp, width: 100.->pct})}
+            cornerRadius=buttonBorderRadius
+            buttonType=nativeProp.configuration.appearance.applePay.buttonType
+            buttonStyle=applePayButtonColor
+          />
+        </TouchableOpacity>
+      | _ => <LoadingOverlay />
       }}
     </View>
   </ErrorBoundary>

--- a/src/pages/widgets/CustomWidget.res
+++ b/src/pages/widgets/CustomWidget.res
@@ -12,7 +12,7 @@ module WidgetError = {
 @react.component
 let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
   let (nativeProp, setNativeProp) = React.useContext(NativePropContext.nativePropContext)
-  let (_, _, sessionTokenData) = React.useContext(
+  let (accountPaymentMethodData, customerPaymentMethodData, sessionTokenData) = React.useContext(
     AllApiDataContextNew.allApiDataContext,
   )
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
@@ -44,17 +44,28 @@ let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
     ->Option.flatMap(sessions => sessions->Array.find(item => item.wallet_name == walletType))
     ->Option.getOr(SessionsType.defaultToken)
 
-  // Build a payment_method_type record for Apple Pay
-  let paymentMethodData: AccountPaymentMethodType.payment_method_type = {
-    payment_method: WALLET,
-    payment_method_str: "wallet",
-    payment_method_type: "apple_pay",
-    payment_method_type_wallet: APPLE_PAY,
-    card_networks: [],
-    bank_names: [],
-    payment_experience: [],
-    required_fields: Dict.make(),
-  }
+  // Find the matching paymentMethodData from accountPaymentMethodData
+  let walletTypeStr = walletType->SdkTypes.walletTypeToStrMapper
+  let paymentMethodDataOpt =
+    accountPaymentMethodData
+    ->Option.flatMap(accountPaymentMethods =>
+      accountPaymentMethods.payment_methods->Array.find(pm =>
+        pm.payment_method_type == walletTypeStr
+      )
+    )
+
+  let paymentMethodData =
+    paymentMethodDataOpt
+    ->Option.getOr({
+      payment_method: WALLET,
+      payment_method_str: "wallet",
+      payment_method_type: walletTypeStr,
+      payment_method_type_wallet: walletType,
+      card_networks: [],
+      bank_names: [],
+      payment_experience: [],
+      required_fields: Dict.make(),
+    })
 
   let errorCallback = (~errorMessage: PaymentConfirmTypes.error, ~closeSDK, ()) => {
     setLoading(FillingDetails)
@@ -74,7 +85,11 @@ let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
   }
 
   // Reads nativePropRef.current to avoid stale closure over nativeProp.
-  let processRequest = (walletDict, email) => {
+  let processRequest = (
+    initialValues: Dict.t<JSON.t>,
+    walletDict: option<Dict.t<JSON.t>>,
+    email: option<string>,
+  ) => {
     let currentNativeProp = nativePropRef.current
 
     // Guard: don't confirm with empty credentials
@@ -82,36 +97,47 @@ let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
       setLoading(FillingDetails)
       showAlert(~errorType="error", ~message="Payment session not initialized")
     } else {
-      let payment_method_data =
-        walletDict->Option.map(dict =>
-          [("wallet", [("apple_pay", dict->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object)]
-          ->Dict.fromArray
-          ->JSON.Encode.object
-        )
+      let paymentMethodDataBody =
+        [
+          (
+            "payment_method_data",
+            [
+              (
+                paymentMethodData.payment_method_str,
+                [
+                  (
+                    paymentMethodData.payment_method_type,
+                    walletDict->Option.getOr(Dict.make())->JSON.Encode.object,
+                  ),
+                ]
+                ->Dict.fromArray
+                ->JSON.Encode.object,
+              ),
+            ]
+            ->Dict.fromArray
+            ->JSON.Encode.object,
+          ),
+        ]->Dict.fromArray
 
-      let body: PaymentConfirmTypes.redirectType = {
-        client_secret: currentNativeProp.clientSecret,
-        return_url: ?Utils.getReturnUrl(~appId=currentNativeProp.hyperParams.appId),
-        ?email,
-        payment_method: "wallet",
-        payment_method_type: "apple_pay",
-        ?payment_method_data,
-        customer_acceptance: ?(
-          Some({
-            acceptance_type: "online",
-            accepted_at: Date.now()->Date.fromTime->Date.toISOString,
-            online: {
-              user_agent: ?currentNativeProp.hyperParams.userAgent,
-            },
-          })
-        ),
-        browser_info: {
-          user_agent: ?currentNativeProp.hyperParams.userAgent,
-          device_model: ?currentNativeProp.hyperParams.device_model,
-          os_type: ?currentNativeProp.hyperParams.os_type,
-          os_version: ?currentNativeProp.hyperParams.os_version,
-        },
-      }
+      let body = PaymentUtils.generateCardConfirmBody(
+        ~nativeProp=currentNativeProp,
+        ~payment_method_str=paymentMethodData.payment_method_str,
+        ~payment_method_type=paymentMethodData.payment_method_type,
+        ~payment_method_data=?CommonUtils.mergeDict(paymentMethodDataBody, initialValues)
+          ->Dict.get("payment_method_data"),
+        ~payment_type=accountPaymentMethodData
+          ->Option.map(apm => apm.payment_type)
+          ->Option.getOr(NORMAL),
+        ~payment_type_str=?accountPaymentMethodData
+          ->Option.flatMap(apm => apm.payment_type_str),
+        ~appURL=?accountPaymentMethodData->Option.map(apm => apm.redirect_url),
+        ~isSaveCardCheckboxVisible=false,
+        ~isGuestCustomer=customerPaymentMethodData
+          ->Option.map(cpm => cpm.is_guest_customer)
+          ->Option.getOr(true),
+        ~email?,
+        (),
+      )
 
       fetchAndRedirect(
         ~body=body->JSON.stringifyAny->Option.getOr(""),
@@ -119,7 +145,8 @@ let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
         ~clientSecret=currentNativeProp.clientSecret,
         ~errorCallback,
         ~responseCallback,
-        ~paymentMethod="apple_pay",
+        ~paymentMethod=paymentMethodData.payment_method_type,
+        ~paymentExperience=paymentMethodData.payment_experience,
         (),
       )
     }
@@ -141,10 +168,10 @@ let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
     setInitialValueCountry(defaultCountry)
 
     if !isFieldsMissing {
-      let email = initialValues->Dict.get("email")->Option.flatMap(JSON.Decode.string)
       processRequest(
+        initialValues,
         Some(walletDict),
-        email,
+        initialValues->Dict.get("email")->Option.flatMap(JSON.Decode.string),
       )
     } else {
       setLoading(FillingDetails)
@@ -308,7 +335,7 @@ let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
     <View
       style={s({flex: 1., width: 100.->pct, maxHeight: 45.->dp, backgroundColor: "transparent"})}>
       {switch walletType {
-      | APPLE_PAY =>
+      | APPLE_PAY when paymentMethodDataOpt->Option.isSome && sessionObject.wallet_name !== NONE =>
         <TouchableOpacity onPress={_ => pressHandler()} activeOpacity=0.8>
           <ApplePayButtonView
             style={s({height: primaryButtonHeight->dp, width: 100.->pct})}
@@ -317,6 +344,7 @@ let make = (~walletType: SdkTypes.payment_method_type_wallet) => {
             buttonStyle=applePayButtonColor
           />
         </TouchableOpacity>
+      | APPLE_PAY => <LoadingOverlay />
       | _ => <LoadingOverlay />
       }}
     </View>

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -254,6 +254,7 @@ type sdkState =
 let widgetToStrMapper = str => {
   switch str {
   | GOOGLE_PAY => "GOOGLE_PAY"
+  | APPLE_PAY => "APPLE_PAY"
   | PAYPAL => "PAYPAL"
   | _ => ""
   }
@@ -879,6 +880,7 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
     | "widgetButtonSheet" => WidgetButtonSheet
     | "hostedCheckout" => HostedCheckout
     | "google_pay" => CustomWidget(GOOGLE_PAY)
+    | "apple_pay" => CustomWidget(APPLE_PAY)
     | "paypal" => CustomWidget(PAYPAL)
     | "card" => CardWidget
     | "paymentMethodsManagement" => PaymentMethodsManagement


### PR DESCRIPTION
## Summary

Add a self-contained Apple Pay widget that renders its own button, launches the native Apple Pay payment sheet, collects the payment token, and confirms the payment — all within a single embeddable widget.

## Changes

### `src/pages/widgets/CustomWidget.res` (rewritten, +306/-61)
- Full Apple Pay widget implementation (~305 lines) replacing the previous stub
- Renders an Apple Pay button using the existing `<ApplePay>` component
- Implements the widget communication protocol: sends `readyMessage` on mount, receives credentials via native `"widget"` event, confirms payment via `fetchAndRedirect`
- Uses `nativePropRef` pattern to prevent stale closures — widget starts with empty `nativeProp` and receives credentials asynchronously
- **No auto-confirm**: Apple requires user gesture to present the payment sheet (Apple Human Interface Guidelines), so `confirm: true` from native is intentionally not acted upon
- Handles wallet token parsing via `handleWalletPayments` and payment body construction via `processWalletData`
- Real PML lookup from `accountPaymentMethodData` context via `walletTypeToStrMapper`
- Uses `PaymentUtils.generateCardConfirmBody` + `CommonUtils.mergeDict` for confirm body (canonical pattern from `ButtonElement.res`)
- Required-fields pipeline: calls `getRequiredFieldsForButton` from `DynamicFieldsContext` before confirm
- Render gated: only shows ApplePay button when `sessionObject.wallet_name !== NONE` AND `paymentMethodDataOpt->Option.isSome`

### `src/types/SdkTypes.res` (+2 lines)
- **Bug fix**: Added `"apple_pay"` case to sdkState parser (was falling to `NoView`)
- **Bug fix**: Added `APPLE_PAY` to `widgetToStrMapper` (was returning empty string, breaking `exitWidget` and `sendReadyMessage`)

## Widget Communication Flow

```
1. Widget mounts → NativeEventListener.sendReadyMessage("apple_pay")
2. Native sends "widget" event → {clientSecret, publishableKey, confirm, paymentMethodType}
3. Widget updates nativeProp context with credentials
4. Sessions + PML data load from backend
5. User taps Apple Pay button → pressHandler guards on session+PML → HyperModule.launchApplePay
6. Native Apple Pay SDK returns token → handleWalletPayments → processWalletData
7. getRequiredFieldsForButton check → generateCardConfirmBody + mergeDict
8. POST /payments/{id}/confirm → exitWidget(status, "apple_pay")
```

## Data Flow

- **Session token**: From `AllApiDataContextNew` → `sessionTokenData` → find `wallet_name == APPLE_PAY`
- **PML data**: From `AllApiDataContextNew` → `accountPaymentMethodData` → find `payment_method_type == "apple_pay"`
- **Required fields**: From `DynamicFieldsContext` → `getRequiredFieldsForButton(paymentMethodData)`
- **Confirm body**: `PaymentUtils.generateCardConfirmBody` merged with wallet-specific fields via `CommonUtils.mergeDict`

## Testing

- ReScript compilation passes (`npm run re:check` with `-warn-error +a-4-9`)
- Security scan passes (gitleaks)
- Requires native iOS integration testing for end-to-end verification (Apple Pay is iOS-only)
