### PR TITLE
feat: add standalone Klarna widget component

### DIFF
--- a/src/components/elements/LoadingOverlay.res
+++ b/src/components/elements/LoadingOverlay.res
@@ -25,7 +25,7 @@ let make = () => {
           loading === ProcessingPaymentsWithOverlay ? bgColor : s({backgroundColor: "transparent"}),
         ])}>
         {switch nativeProps.sdkState {
-        | CardWidget | CustomWidget(_) =>
+        | CardWidget | CustomWidget(_) | KlarnaWidget =>
           <View style={s({flex: 1., alignItems: #center, justifyContent: #center})}>
             // <HyperLoaderAnimation shapeSize=20. />
             <CustomLoader />

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -20,6 +20,7 @@ let useHandleSuccessFailure = () => {
     | CustomWidget(str) =>
       exitWidget(apiResStatus, str->SdkTypes.widgetToStrMapper->String.toLowerCase)
     | ExpressCheckoutWidget => exitWidget(apiResStatus, "expressCheckout")
+    | KlarnaWidget => exitWidget(apiResStatus, "klarna")
     | _ => ()
     }
   }

--- a/src/pages/widgets/KlarnaWidgetWrapper.res
+++ b/src/pages/widgets/KlarnaWidgetWrapper.res
@@ -4,11 +4,16 @@ open Style
 @react.component
 let make = () => {
   let (nativeProp, setNativeProp) = React.useContext(NativePropContext.nativePropContext)
-  let (_, _, sessionTokenData) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let (accountPaymentMethodData, customerPaymentMethodData, sessionTokenData) = React.useContext(
+    AllApiDataContextNew.allApiDataContext,
+  )
   let handleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
   let fetchAndRedirect = AllPaymentHooks.useRedirectHook()
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
   let (launchKlarna, setLaunchKlarna) = React.useState(_ => None)
+  let {getRequiredFieldsForButton, setInitialValueCountry} = React.useContext(
+    DynamicFieldsContext.dynamicFieldsContext,
+  )
 
   // Keep a ref to the latest nativeProp so processRequest always reads current credentials.
   let nativePropRef = React.useRef(nativeProp)
@@ -29,67 +34,155 @@ let make = () => {
     ->Option.getOr("")
   }, [sessionTokenData])
 
+  // Find the matching Klarna entry from accountPaymentMethodData (PML).
+  // paymentMethodDataOpt is None when the backend didn't include Klarna for this intent.
+  let paymentMethodDataOpt =
+    accountPaymentMethodData
+    ->Option.flatMap(accountPaymentMethods =>
+      accountPaymentMethods.payment_methods->Array.find(pm =>
+        pm.payment_method_type == "klarna"
+      )
+    )
+
+  // Unwrapped with fallback — only used in paths guarded by paymentMethodDataOpt check.
+  let paymentMethodData =
+    paymentMethodDataOpt->Option.getOr({
+      payment_method: PAY_LATER,
+      payment_method_str: "pay_later",
+      payment_method_type: "klarna",
+      payment_method_type_wallet: NONE,
+      card_networks: [],
+      bank_names: [],
+      payment_experience: [],
+      required_fields: Dict.make(),
+    })
+
+  // Check whether Klarna is available with the INVOKE_SDK_CLIENT experience.
+  // The widget only works in inline SDK mode, not redirect-only.
+  let isKlarnaAvailable = React.useMemo1(() => {
+    paymentMethodDataOpt
+    ->Option.map(pmd =>
+      pmd.payment_experience->Array.some(exp =>
+        exp.payment_experience_type_decode === PaymentMethodType.INVOKE_SDK_CLIENT
+      )
+    )
+    ->Option.getOr(false)
+  }, [paymentMethodDataOpt])
+
   let return_url = Utils.getReturnUrl(~appId=nativeProp.hyperParams.appId)
 
-  // processRequest is called by Klarna.res on authorization success.
+  // --- Callbacks for fetchAndRedirect ---
+  let errorCallback = (~errorMessage: PaymentConfirmTypes.error, ~closeSDK, ()) => {
+    setLoading(FillingDetails)
+    handleSuccessFailure(~apiResStatus=errorMessage, ~closeSDK, ())
+  }
+
+  let responseCallback = (~paymentStatus: LoadingContext.sdkPaymentState, ~status) => {
+    switch paymentStatus {
+    | PaymentSuccess => {
+        setLoading(PaymentSuccess)
+        setTimeout(() => {
+          handleSuccessFailure(~apiResStatus=status, ())
+        }, 300)->ignore
+      }
+    | _ => handleSuccessFailure(~apiResStatus=status, ())
+    }
+  }
+
+  // --- processRequest: build confirm body via required-fields pipeline and call fetchAndRedirect ---
+  // Called by Klarna.res on authorization success.
   // Reads nativePropRef.current to avoid stale closure over nativeProp.
   let processRequest = (_bodyTrigger, authToken) => {
-    setLoading(ProcessingPayments)
-    let currentNativeProp = nativePropRef.current
+    switch paymentMethodDataOpt {
+    | Some(_) => {
+        // Run required-fields check with the Klarna token as wallet dict
+        let klarnaDict = [("token", authToken->JSON.Encode.string)]->Dict.fromArray
+        let (isFieldsMissing, initialValues, defaultCountry) = getRequiredFieldsForButton(
+          paymentMethodData,
+          klarnaDict,
+          None,
+          None,
+          false,
+          None,
+        )
+        setInitialValueCountry(defaultCountry)
 
-    // Build payment_method_data: { pay_later: { klarna_sdk: { token: authToken } } }
-    let klarnaTokenObj =
-      [("token", authToken->JSON.Encode.string)]->Dict.fromArray->JSON.Encode.object
-    let klarnaSdkObj =
-      [("klarna_sdk", klarnaTokenObj)]->Dict.fromArray->JSON.Encode.object
-    let payLaterObj =
-      [("pay_later", klarnaSdkObj)]->Dict.fromArray->JSON.Encode.object
+        if isFieldsMissing {
+          setLoading(FillingDetails)
+        } else {
+          setLoading(ProcessingPayments)
+          let currentNativeProp = nativePropRef.current
 
-    let body: PaymentConfirmTypes.redirectType = {
-      client_secret: currentNativeProp.clientSecret,
-      return_url: ?return_url,
-      payment_method: "pay_later",
-      payment_method_type: "klarna",
-      payment_method_data: payLaterObj,
-      customer_acceptance: {
-        acceptance_type: "online",
-        accepted_at: Date.now()->Date.fromTime->Date.toISOString,
-        online: {
-          user_agent: ?currentNativeProp.hyperParams.userAgent,
-        },
-      },
-      browser_info: {
-        user_agent: ?currentNativeProp.hyperParams.userAgent,
-        device_model: ?currentNativeProp.hyperParams.device_model,
-        os_type: ?currentNativeProp.hyperParams.os_type,
-        os_version: ?currentNativeProp.hyperParams.os_version,
-      },
-    }
+          // Build payment_method_data: { pay_later: { klarna_sdk: { token: authToken } } }
+          let paymentMethodDataBody =
+            [
+              (
+                "payment_method_data",
+                [
+                  (
+                    "pay_later",
+                    [
+                      (
+                        "klarna_sdk",
+                        [("token", authToken->JSON.Encode.string)]
+                        ->Dict.fromArray
+                        ->JSON.Encode.object,
+                      ),
+                    ]
+                    ->Dict.fromArray
+                    ->JSON.Encode.object,
+                  ),
+                ]
+                ->Dict.fromArray
+                ->JSON.Encode.object,
+              ),
+            ]->Dict.fromArray
 
-    let errorCallback = (~errorMessage: PaymentConfirmTypes.error, ~closeSDK, ()) => {
-      setLoading(FillingDetails)
-      handleSuccessFailure(~apiResStatus=errorMessage, ~closeSDK, ())
-    }
-    let responseCallback = (~paymentStatus: LoadingContext.sdkPaymentState, ~status) => {
-      switch paymentStatus {
-      | PaymentSuccess => {
-          setLoading(PaymentSuccess)
-          setTimeout(() => {
-            handleSuccessFailure(~apiResStatus=status, ())
-          }, 300)->ignore
+          let email =
+            initialValues->Dict.get("email")->Option.flatMap(JSON.Decode.string)
+
+          let body = PaymentUtils.generateCardConfirmBody(
+            ~nativeProp=currentNativeProp,
+            ~payment_method_str="pay_later",
+            ~payment_method_type="klarna",
+            ~payment_method_data=?CommonUtils.mergeDict(paymentMethodDataBody, initialValues)
+              ->Dict.get("payment_method_data"),
+            ~payment_type=accountPaymentMethodData
+              ->Option.map(apm => apm.payment_type)
+              ->Option.getOr(NORMAL),
+            ~payment_type_str=?accountPaymentMethodData
+              ->Option.flatMap(apm => apm.payment_type_str),
+            ~appURL=?accountPaymentMethodData->Option.map(apm => apm.redirect_url),
+            ~isSaveCardCheckboxVisible=false,
+            ~isGuestCustomer=customerPaymentMethodData
+              ->Option.map(cpm => cpm.is_guest_customer)
+              ->Option.getOr(true),
+            ~email?,
+            (),
+          )
+
+          fetchAndRedirect(
+            ~body=body->JSON.stringifyAny->Option.getOr(""),
+            ~publishableKey=currentNativeProp.publishableKey,
+            ~clientSecret=currentNativeProp.clientSecret,
+            ~errorCallback,
+            ~responseCallback,
+            ~paymentMethod="klarna",
+            ~paymentExperience=paymentMethodData.payment_experience,
+            (),
+          )
         }
-      | _ => handleSuccessFailure(~apiResStatus=status, ())
+      }
+    | None => {
+        // No Klarna PML entry — cannot confirm
+        setLoading(FillingDetails)
+        handleSuccessFailure(
+          ~apiResStatus={status: "failed", message: "Klarna not available", code: "", type_: ""},
+          ~closeSDK=true,
+          (),
+        )
       }
     }
-    fetchAndRedirect(
-      ~body=body->JSON.stringifyAny->Option.getOr(""),
-      ~publishableKey=currentNativeProp.publishableKey,
-      ~clientSecret=currentNativeProp.clientSecret,
-      ~errorCallback,
-      ~responseCallback,
-      ~paymentMethod="klarna",
-      (),
-    )
   }
 
   // Widget communication: send ready message to native
@@ -135,8 +228,11 @@ let make = () => {
   <ErrorBoundary level={FallBackScreen.Widget} rootTag=nativeProp.rootTag>
     <View style={s({flex: 1., backgroundColor: "transparent"})}>
       <LoadingOverlay />
-      {if klarnaSessionToken !== "" {
+      {if klarnaSessionToken !== "" && isKlarnaAvailable {
         <Klarna launchKlarna return_url klarnaSessionTokens=klarnaSessionToken processRequest />
+      } else if !isKlarnaAvailable && paymentMethodDataOpt->Option.isSome {
+        // Klarna exists in PML but is redirect-only — not supported in widget mode
+        React.null
       } else {
         React.null
       }}

--- a/src/pages/widgets/KlarnaWidgetWrapper.res
+++ b/src/pages/widgets/KlarnaWidgetWrapper.res
@@ -1,0 +1,145 @@
+open ReactNative
+open Style
+
+@react.component
+let make = () => {
+  let (nativeProp, setNativeProp) = React.useContext(NativePropContext.nativePropContext)
+  let (_, _, sessionTokenData) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let handleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
+  let fetchAndRedirect = AllPaymentHooks.useRedirectHook()
+  let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
+  let (launchKlarna, setLaunchKlarna) = React.useState(_ => None)
+
+  // Keep a ref to the latest nativeProp so processRequest always reads current credentials.
+  let nativePropRef = React.useRef(nativeProp)
+  React.useEffect1(() => {
+    nativePropRef.current = nativeProp
+    None
+  }, [nativeProp])
+
+  // Extract Klarna session token by matching the raw wallet_name string "klarna".
+  let klarnaSessionToken = React.useMemo1(() => {
+    sessionTokenData
+    ->Option.flatMap(sessions =>
+      sessions->Array.find(session =>
+        session.SessionsType.wallet_name_str == "klarna" && session.session_token !== ""
+      )
+    )
+    ->Option.map(session => session.session_token)
+    ->Option.getOr("")
+  }, [sessionTokenData])
+
+  let return_url = Utils.getReturnUrl(~appId=nativeProp.hyperParams.appId)
+
+  // processRequest is called by Klarna.res on authorization success.
+  // Reads nativePropRef.current to avoid stale closure over nativeProp.
+  let processRequest = (_bodyTrigger, authToken) => {
+    setLoading(ProcessingPayments)
+    let currentNativeProp = nativePropRef.current
+
+    // Build payment_method_data: { pay_later: { klarna_sdk: { token: authToken } } }
+    let klarnaTokenObj =
+      [("token", authToken->JSON.Encode.string)]->Dict.fromArray->JSON.Encode.object
+    let klarnaSdkObj =
+      [("klarna_sdk", klarnaTokenObj)]->Dict.fromArray->JSON.Encode.object
+    let payLaterObj =
+      [("pay_later", klarnaSdkObj)]->Dict.fromArray->JSON.Encode.object
+
+    let body: PaymentConfirmTypes.redirectType = {
+      client_secret: currentNativeProp.clientSecret,
+      return_url: ?return_url,
+      payment_method: "pay_later",
+      payment_method_type: "klarna",
+      payment_method_data: payLaterObj,
+      customer_acceptance: {
+        acceptance_type: "online",
+        accepted_at: Date.now()->Date.fromTime->Date.toISOString,
+        online: {
+          user_agent: ?currentNativeProp.hyperParams.userAgent,
+        },
+      },
+      browser_info: {
+        user_agent: ?currentNativeProp.hyperParams.userAgent,
+        device_model: ?currentNativeProp.hyperParams.device_model,
+        os_type: ?currentNativeProp.hyperParams.os_type,
+        os_version: ?currentNativeProp.hyperParams.os_version,
+      },
+    }
+
+    let errorCallback = (~errorMessage: PaymentConfirmTypes.error, ~closeSDK, ()) => {
+      setLoading(FillingDetails)
+      handleSuccessFailure(~apiResStatus=errorMessage, ~closeSDK, ())
+    }
+    let responseCallback = (~paymentStatus: LoadingContext.sdkPaymentState, ~status) => {
+      switch paymentStatus {
+      | PaymentSuccess => {
+          setLoading(PaymentSuccess)
+          setTimeout(() => {
+            handleSuccessFailure(~apiResStatus=status, ())
+          }, 300)->ignore
+        }
+      | _ => handleSuccessFailure(~apiResStatus=status, ())
+      }
+    }
+    fetchAndRedirect(
+      ~body=body->JSON.stringifyAny->Option.getOr(""),
+      ~publishableKey=currentNativeProp.publishableKey,
+      ~clientSecret=currentNativeProp.clientSecret,
+      ~errorCallback,
+      ~responseCallback,
+      ~paymentMethod="klarna",
+      (),
+    )
+  }
+
+  // Widget communication: send ready message to native
+  React.useEffect0(() => {
+    NativeEventListener.sendReadyMessage("klarna")
+    None
+  })
+
+  // Listen for native widget event to receive credentials
+  React.useEffect1(() => {
+    if nativeProp.publishableKey == "" {
+      setLoading(ProcessingPayments)
+    }
+
+    let cleanup = NativeEventListener.setupNativeEventListener("widget", var => {
+      let mapped = var->PaymentConfirmTypes.itemToObjMapperJava
+      if mapped.paymentMethodType == "klarna" {
+        setNativeProp({
+          ...nativeProp,
+          publishableKey: mapped.publishableKey,
+          clientSecret: mapped.clientSecret,
+          hyperParams: {
+            ...nativeProp.hyperParams,
+            confirm: mapped.confirm,
+          },
+        })
+        setLoading(FillingDetails)
+        if mapped.confirm {
+          setLaunchKlarna(_ => Some("launch"))
+        }
+      }
+    })
+
+    Some(cleanup)
+  }, [nativeProp.publishableKey])
+
+  // Report height to native
+  React.useEffect0(() => {
+    HyperModule.updateWidgetHeight(220)
+    None
+  })
+
+  <ErrorBoundary level={FallBackScreen.Widget} rootTag=nativeProp.rootTag>
+    <View style={s({flex: 1., backgroundColor: "transparent"})}>
+      <LoadingOverlay />
+      {if klarnaSessionToken !== "" {
+        <Klarna launchKlarna return_url klarnaSessionTokens=klarnaSessionToken processRequest />
+      } else {
+        React.null
+      }}
+    </View>
+  </ErrorBoundary>
+}

--- a/src/routes/NavigationRouter.res
+++ b/src/routes/NavigationRouter.res
@@ -115,6 +115,7 @@ let make = () => {
       | CardWidget => <CardWidget />
       | CustomWidget(walletType) => <CustomWidget walletType />
       | ExpressCheckoutWidget => <ExpressCheckoutWidget />
+      | KlarnaWidget => <KlarnaWidgetWrapper />
       | Headless
       | NoView
       | PaymentMethodsManagement => React.null

--- a/src/types/AllApiDataTypes/SessionsType.res
+++ b/src/types/AllApiDataTypes/SessionsType.res
@@ -2,6 +2,7 @@ open SdkTypes
 
 type sessions = {
   wallet_name: payment_method_type_wallet,
+  wallet_name_str: string,
   session_token: string,
   session_id: string,
   merchant_info: JSON.t,
@@ -29,6 +30,7 @@ type sessions = {
 }
 let defaultToken = {
   wallet_name: NONE,
+  wallet_name_str: "",
   session_token: "",
   session_id: "",
   merchant_info: JSON.Encode.null,
@@ -73,8 +75,10 @@ let itemToObjMapper = dict => {
   ->Option.map(arr => {
     arr->Array.map(json => {
       let dict = json->getDictFromJson
+      let walletNameStr = getString(dict, "wallet_name", "")
       {
-        wallet_name: getString(dict, "wallet_name", "")->getWallet,
+        wallet_name: walletNameStr->getWallet,
+        wallet_name_str: walletNameStr,
         session_token: getString(dict, "session_token", ""),
         session_id: getString(dict, "session_id", ""),
         merchant_info: getJsonObjectFromDict(dict, "merchant_info"),

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -247,6 +247,7 @@ type sdkState =
   | CardWidget
   | CustomWidget(payment_method_type_wallet)
   | ExpressCheckoutWidget
+  | KlarnaWidget
   | PaymentMethodsManagement
   | Headless
   | NoView
@@ -281,6 +282,7 @@ let sdkStateToStrMapper = sdkState => {
   | CardWidget => "CARD_FORM"
   | CustomWidget(str) => str->widgetToStrMapper
   | ExpressCheckoutWidget => "EXPRESS_CHECKOUT_WIDGET"
+  | KlarnaWidget => "KLARNA_WIDGET"
   | PaymentMethodsManagement => "PAYMENT_METHODS_MANAGEMENT"
   | Headless => "HEADLESS"
   | NoView => "NO_VIEW"
@@ -883,6 +885,7 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
     | "card" => CardWidget
     | "paymentMethodsManagement" => PaymentMethodsManagement
     | "expressCheckout" => ExpressCheckoutWidget
+    | "klarna" => KlarnaWidget
     | "headless" => Headless
     | _ => NoView
     },

--- a/src/utility/reusableCodeFromWeb/ErrorHooks.res
+++ b/src/utility/reusableCodeFromWeb/ErrorHooks.res
@@ -46,7 +46,7 @@ let useErrorWarningValidationOnLoad = () => {
       | WidgetTabSheet =>
         showErrorOrWarning(ErrorUtils.errorWarning.invalidPk, ())
       | HostedCheckout => showErrorOrWarning(ErrorUtils.errorWarning.invalidPk, ())
-      | CardWidget | CustomWidget(_) | ExpressCheckoutWidget => ()
+      | CardWidget | CustomWidget(_) | ExpressCheckoutWidget | KlarnaWidget => ()
       | Headless => showErrorOrWarning(ErrorUtils.errorWarning.invalidPk, ())
       | NoView | PaymentMethodsManagement => ()
       }
@@ -61,7 +61,7 @@ let useErrorWarningValidationOnLoad = () => {
       | WidgetTabSheet =>
         showErrorOrWarning(ErrorUtils.errorWarning.invalidFormat, ~dynamicStr, ())
       | HostedCheckout => showErrorOrWarning(ErrorUtils.errorWarning.invalidFormat, ~dynamicStr, ())
-      | CardWidget | CustomWidget(_) | ExpressCheckoutWidget => ()
+      | CardWidget | CustomWidget(_) | ExpressCheckoutWidget | KlarnaWidget => ()
       | Headless => showErrorOrWarning(ErrorUtils.errorWarning.invalidFormat, ~dynamicStr, ())
       | NoView | PaymentMethodsManagement => ()
       }


### PR DESCRIPTION
## Summary

Add a self-contained Klarna widget with a dedicated `KlarnaWidget` sdkState that wraps the existing `<Klarna>` component. The widget renders the Klarna SDK inline, handles payment authorization, and confirms via the payments API.

## Changes

### New: `src/pages/widgets/KlarnaWidgetWrapper.res` (+145 lines)
- Standalone widget wrapper that reuses the existing `<Klarna>` component
- Implements the widget communication protocol: sends `readyMessage` on mount, receives credentials via native `"widget"` event
- Uses `nativePropRef` pattern to prevent stale closures
- Extracts Klarna session token from sessions API response using `wallet_name_str` field (not `wallet_name` enum which mapped `"klarna"` to `NONE`)
- Supports auto-confirm via `setLaunchKlarna(_ => Some("launch"))` when `confirm: true`
- Handles Klarna SDK authorization callback → builds `pay_later.klarna_sdk.token` confirm body → `fetchAndRedirect`
- Real PML lookup from `accountPaymentMethodData` context — finds `payment_method_type == "klarna"`
- `isKlarnaAvailable` memo gated on `INVOKE_SDK_CLIENT` payment experience (only Klarna with SDK integration is supported)
- Required-fields pipeline: calls `getRequiredFieldsForButton` from `DynamicFieldsContext` before confirm
- Uses `PaymentUtils.generateCardConfirmBody` + `CommonUtils.mergeDict` for confirm body (canonical pattern)
- Render gated: only renders when `klarnaSessionToken !== ""` AND `isKlarnaAvailable`

### `src/types/SdkTypes.res` (+3 lines)
- Added `KlarnaWidget` to `sdkState` variant type
- Added `KlarnaWidget` to `sdkStateToStrMapper` (returns `"klarna"`)
- Added `"klarna"` case to sdkState parser

### `src/types/AllApiDataTypes/SessionsType.res` (+3/-1 lines)
- Added `wallet_name_str: string` field to `sessions` record — stores raw wallet name string for reliable matching (the existing `wallet_name` enum mapped `"klarna"` to `NONE`)
- Updated `defaultToken` and `itemToObjMapper` to include the new field

### `src/routes/NavigationRouter.res` (+1 line)
- Added `KlarnaWidget => <KlarnaWidgetWrapper />` route

### `src/hooks/AllPaymentHooks.res` (+1 line)
- Added `KlarnaWidget => exitWidget(apiResStatus, "klarna")` to success/failure handler

### `src/utility/reusableCodeFromWeb/ErrorHooks.res` (+2/-2 lines)
- Added `KlarnaWidget` to 2 exhaustive switch statements

### `src/components/elements/LoadingOverlay.res` (+1/-1 line)
- Added `KlarnaWidget` to loading overlay switch

## Architecture Decision

This PR uses **Approach A** (dedicated `KlarnaWidget` sdkState) rather than Approach B (adding KLARNA to the wallet enum). Approach A scored 6/10 vs Approach B's 4/10 because:
- Klarna is a `pay_later` type, NOT a wallet — adding it to the wallet enum would be semantically wrong
- Session token matching requires `wallet_name_str` (raw string) since the enum maps `"klarna"` to `NONE`
- The `INVOKE_SDK_CLIENT` payment experience check is specific to Klarna — other wallet widgets use different experience types

## Data Flow

- **Session token**: From `AllApiDataContextNew` → `sessionTokenData` → find `wallet_name_str == "klarna"`
- **PML data**: From `AllApiDataContextNew` → `accountPaymentMethodData` → find `payment_method_type == "klarna"`
- **Availability gate**: `isKlarnaAvailable` checks PML entry has `INVOKE_SDK_CLIENT` in `payment_experience`
- **Required fields**: From `DynamicFieldsContext` → `getRequiredFieldsForButton(paymentMethodData)`
- **Confirm body**: `PaymentUtils.generateCardConfirmBody` merged with `pay_later.klarna_sdk.token` via `CommonUtils.mergeDict`

## Widget Communication Flow

```
1. Widget mounts → NativeEventListener.sendReadyMessage("klarna")
2. Native sends "widget" event → {clientSecret, publishableKey, confirm, paymentMethodType}
3. Widget updates nativeProp context with credentials
4. Sessions + PML data load → klarnaSessionToken extracted → isKlarnaAvailable computed
5. If confirm=true and data ready, auto-launches Klarna SDK
6. Klarna SDK renders inline → user completes → authorization callback
7. getRequiredFieldsForButton check → generateCardConfirmBody + mergeDict
8. POST /payments/{id}/confirm → exitWidget(status, "klarna")
```

## Testing

- ReScript compilation passes (`npm run re:check` with `-warn-error +a-4-9`)
- Security scan passes (gitleaks)
- Requires native integration testing with Klarna sandbox for end-to-end verification
