### PR TITLE
feat: add savedPaymentMethodsCheckboxCheckedByDefault config prop

### DIFF
--- a/src/contexts/DynamicFieldsContext.res
+++ b/src/contexts/DynamicFieldsContext.res
@@ -361,7 +361,9 @@ let make = (~children) => {
     (isFieldsMissing, initialValues, defaultCountry)
   }
 
-  let (isNicknameSelected, setIsNicknameSelected) = React.useState(_ => false)
+  let (isNicknameSelected, setIsNicknameSelected) = React.useState(_ =>
+    nativeProp.configuration.savedPaymentMethodsCheckboxCheckedByDefault
+  )
   let setIsNicknameSelected = React.useCallback1(val => {
     setIsNicknameSelected(_ => val)
   }, [setIsNicknameSelected])

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -31,7 +31,9 @@ let make = (
 
   let (errorText, setErrorText) = React.useState(_ => None)
 
-  let (isSaveCardCheckboxSelected, setSaveCardChecboxSelected) = React.useState(_ => false)
+  let (isSaveCardCheckboxSelected, setSaveCardChecboxSelected) = React.useState(_ =>
+    nativeProp.configuration.savedPaymentMethodsCheckboxCheckedByDefault
+  )
   let setSaveCardChecboxSelected = React.useCallback1(isSelected => {
     if isSelected {
       setErrorText(_ => None)

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -226,6 +226,7 @@ type configurationType = {
   primaryButtonColor: option<string>,
   allowsPaymentMethodsRequiringShippingAddress: bool,
   displaySavedPaymentMethodsCheckbox: bool,
+  savedPaymentMethodsCheckboxCheckedByDefault: bool,
   displaySavedPaymentMethods: bool,
   placeholder: placeholder,
   defaultView: bool,
@@ -824,6 +825,11 @@ let parseConfigurationDict = (configObj, from) => {
     displaySavedPaymentMethodsCheckbox: getBool(
       configObj,
       "displaySavedPaymentMethodsCheckbox",
+      true,
+    ),
+    savedPaymentMethodsCheckboxCheckedByDefault: getBool(
+      configObj,
+      "savedPaymentMethodsCheckboxCheckedByDefault",
       true,
     ),
     displaySavedPaymentMethods: getBool(configObj, "displaySavedPaymentMethods", true),


### PR DESCRIPTION
## Summary
- Add `savedPaymentMethodsCheckboxCheckedByDefault` configuration prop (default: `false`)
- When `true`, the save card details checkbox is pre-checked by default
## Changes
- `SdkTypes.res`: Added prop to `configurationType` and JSON parsing (default `false`)
- `DynamicFieldsContext.res`: Initialize `isNicknameSelected` from new prop (new card flow checkbox)
- `SavedPaymentSheet.res`: Initialize `isSaveCardCheckboxSelected` from new prop (saved card flow checkbox)
## Depends on
- [juspay/hyperswitch-sdk-android#<PR_NUMBER>](https://github.com/juspay/hyperswitch-sdk-android/pull/96)
- [juspay/hyperswitch-sdk-ios#<PR_NUMBER>](https://github.com/juspay/hyperswitch-sdk-ios/pull/62)