### PR TITLE
fix: added customer_acceptance to saved card confirm body for mandates

### DIFF
--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -103,31 +103,48 @@ let generateSavedCardConfirmBody = (
   ~screen_width=?,
   ~billing=?,
 ): PaymentConfirmTypes.redirectType => {
-  client_secret: nativeProp.clientSecret,
-  payment_method: "card",
-  payment_token,
-  card_cvc: ?(savedCardCvv->Option.isSome ? Some(savedCardCvv->Option.getOr("")) : None),
-  return_url: ?Utils.getReturnUrl(~appId=nativeProp.hyperParams.appId, ~appURL),
-  payment_method_data: ?billing->Option.map(address =>
-    [("billing", address->Utils.getJsonObjectFromRecord)]
-    ->Dict.fromArray
-    ->JSON.Encode.object
-  ),
-  payment_type: ?payment_type_str,
-  browser_info: {
-    user_agent: ?nativeProp.hyperParams.userAgent,
-    accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
-    language: LocaleDataType.localeTypeToString(nativeProp.configuration.appearance.locale),
-    color_depth: 32,
-    screen_height: ?screen_height->Option.map(Int.fromFloat),
-    screen_width: ?screen_width->Option.map(Int.fromFloat),
-    time_zone: Date.make()->Date.getTimezoneOffset,
-    java_enabled: true,
-    java_script_enabled: true,
-    device_model: ?nativeProp.hyperParams.device_model,
-    os_type: ?nativeProp.hyperParams.os_type,
-    os_version: ?nativeProp.hyperParams.os_version,
-  },
+  let isMandate =
+    payment_type_str === Some("new_mandate") || payment_type_str === Some("setup_mandate")
+  {
+    client_secret: nativeProp.clientSecret,
+    payment_method: "card",
+    payment_token,
+    card_cvc: ?(savedCardCvv->Option.isSome ? Some(savedCardCvv->Option.getOr("")) : None),
+    return_url: ?Utils.getReturnUrl(~appId=nativeProp.hyperParams.appId, ~appURL),
+    payment_method_data: ?billing->Option.map(address =>
+      [("billing", address->Utils.getJsonObjectFromRecord)]
+      ->Dict.fromArray
+      ->JSON.Encode.object
+    ),
+    payment_type: ?payment_type_str,
+    customer_acceptance: ?(
+      isMandate
+        ? Some({
+            {
+              acceptance_type: "online",
+              accepted_at: Date.now()->Date.fromTime->Date.toISOString,
+              online: {
+                user_agent: ?nativeProp.hyperParams.userAgent,
+              },
+            }
+          })
+        : None
+    ),
+    browser_info: {
+      user_agent: ?nativeProp.hyperParams.userAgent,
+      accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
+      language: LocaleDataType.localeTypeToString(nativeProp.configuration.appearance.locale),
+      color_depth: 32,
+      screen_height: ?screen_height->Option.map(Int.fromFloat),
+      screen_width: ?screen_width->Option.map(Int.fromFloat),
+      time_zone: Date.make()->Date.getTimezoneOffset,
+      java_enabled: true,
+      java_script_enabled: true,
+      device_model: ?nativeProp.hyperParams.device_model,
+      os_type: ?nativeProp.hyperParams.os_type,
+      os_version: ?nativeProp.hyperParams.os_version,
+    },
+  }
 }
 let generateWalletConfirmBody = (
   ~nativeProp: SdkTypes.nativeProp,

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -119,6 +119,19 @@ let generateSavedCardConfirmBody = (
     ->JSON.Encode.object
   ),
   payment_type: ?payment_type_str,
+  customer_acceptance: ?(
+    payment_type_str === Some("new_mandate") || payment_type_str === Some("setup_mandate")
+      ? Some({
+          {
+            acceptance_type: "online",
+            accepted_at: Date.now()->Date.fromTime->Date.toISOString,
+            online: {
+              user_agent: Utils.resolveUserAgent(~userAgent=nativeProp.sdkParams.userAgent),
+            },
+          }
+        })
+      : None
+  ),
   browser_info: {
     user_agent: Utils.resolveUserAgent(~userAgent=nativeProp.sdkParams.userAgent),
     accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",


### PR DESCRIPTION
## Problem

Saved-card payments were failing for mandate flows (`new_mandate` and `setup_mandate`).

The confirm request generated by `generateSavedCardConfirmBody` did not include `customer_acceptance`, which is required by the backend when setting up a mandate. As a result, saved-card mandate payments were rejected.

## Changes

Added `customer_acceptance` to the saved-card confirm request when `payment_type_str` is either:

* `new_mandate`
* `setup_mandate`

For all other payment types, the field is omitted, leaving existing non-mandate saved-card flows unchanged.

The implementation follows the same pattern already used in `generateCardConfirmBody`:

```rescript
customer_acceptance: ?(
  payment_type_str === Some("new_mandate") ||
  payment_type_str === Some("setup_mandate")
    ? Some({
        acceptance_type: "online",
        accepted_at: Date.now()->Date.fromTime->Date.toISOString,
        online: {
          user_agent: Utils.resolveUserAgent(
            ~userAgent=nativeProp.sdkParams.userAgent,
          ),
        },
      })
    : None
)
```

No function signatures were changed. The mandate state is derived from the existing `payment_type_str` parameter, so no caller updates are required.

## Scope

* Updated a single file: `src/utility/logics/PaymentUtils.res`
* Purely additive change
* No changes to existing request fields
* No behavioral impact on non-mandate saved-card payments

## Testing

* `yarn re:build` passes successfully
* Strict `yarn re:check` passes: **717/717**

## Verification

* Confirmed that saved-card mandate payments include `customer_acceptance` in the confirm request
* Confirmed that regular saved-card payments continue to omit `customer_acceptance`
