### PR TITLE
fix: eligibility paymentid consumption and unused vars removed

### DIFF
--- a/src/components/dynamic/CardElement.res
+++ b/src/components/dynamic/CardElement.res
@@ -191,9 +191,6 @@ let make = (
         None
       }, (cardNumber, expireDate, cvc, brand))
 
-      let cardNumber = cardNumberInput.value->Option.getOr("")
-      let cvc = cardCvcInput.value->Option.getOr("")
-      let brand = cardNetworkInput.value->Option.getOr("")
 
       React.useEffect1(() => {
         let isValid = cardValid(cardNumber, brand)

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -401,12 +401,9 @@ let useEligibilityCheckHook = () => {
     switch WebKit.platform {
     | #next => Promise.resolve(`{"sdk_next_action":{"next_action":"confirm"}}`->JSON.parseExn)
     | _ =>
-      let paymentId =
-        String.split(nativeProp.clientSecret, "_secret_")->Array.get(0)->Option.getOr("")
-      let uri = `${baseUrl}/payments/${paymentId}/eligibility`
+      let uri = `${baseUrl}/payments/${nativeProp.paymentMethodId}/eligibility`
       let body =
         [
-          ("client_secret", nativeProp.clientSecret->JSON.Encode.string),
           ("payment_method_type", paymentMethodType->JSON.Encode.string),
           ("payment_method_data", paymentMethodData),
         ]


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

- The payment_id was initially consumed from client_secret but the client_secret was removed. 

<!-- Brief description of the change -->

---

 - Request : 
 
### Request

```json
{
  "payment_method_type": "card",
  "payment_method_data": {
    "card": {
      "card_number": "4242424242424242"
    }
  }
}
```

 ### Response : 

```{
  "payment_id": "pay_CltxdOM",
  "sdk_next_action": {
    "next_action": {
      "deny": {
        "message": "Card number is blocklisted"
      }
    }
  }
}
```

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [x] Tested in consuming Android app
- [ ] Tested in consuming iOS app
