### PR TITLE
fix: enhance error handling and notifications for payment processes

### DIFF
--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -315,17 +315,36 @@ let make = (
         | Cancelled | Simulated =>
           setLoading(FillingDetails)
           showAlert(~errorType="warning", ~message="Payment was Cancelled")
+          HyperModule.hyperModule.notifyWidgetPaymentResult(
+            nativeProp.rootTag,
+            PaymentConfirmTypes.defaultCancelError->HyperModule.stringifiedResStatus,
+          )
         | Failed(error_message) =>
           setLoading(FillingDetails)
           showAlert(~errorType="error", ~message=error_message)
+          HyperModule.hyperModule.notifyWidgetPaymentResult(
+            nativeProp.rootTag,
+            {
+              ...PaymentConfirmTypes.walletError,
+              message: error_message,
+            }->HyperModule.stringifiedResStatus,
+          )
         }
       | None =>
         setLoading(FillingDetails)
         showAlert(~errorType="error", ~message="Technical Error")
+        HyperModule.hyperModule.notifyWidgetPaymentResult(
+          nativeProp.rootTag,
+          PaymentConfirmTypes.defaultConfirmError->HyperModule.stringifiedResStatus,
+        )
       }
     | None =>
       setLoading(FillingDetails)
       showAlert(~errorType="error", ~message="Technical Error")
+      HyperModule.hyperModule.notifyWidgetPaymentResult(
+        nativeProp.rootTag,
+        PaymentConfirmTypes.defaultConfirmError->HyperModule.stringifiedResStatus,
+      )
     }
   }
 
@@ -358,24 +377,50 @@ let make = (
         | Cancelled =>
           setLoading(FillingDetails)
           showAlert(~errorType="warning", ~message="Cancelled")
+          HyperModule.hyperModule.notifyWidgetPaymentResult(
+            nativeProp.rootTag,
+            PaymentConfirmTypes.defaultCancelError->HyperModule.stringifiedResStatus,
+          )
         | Simulated => setTimeout(() => {
             setLoading(FillingDetails)
             showAlert(
               ~errorType="warning",
               ~message="Apple Pay is not supported in Simulated Environment",
             )
+            HyperModule.hyperModule.notifyWidgetPaymentResult(
+              nativeProp.rootTag,
+              {
+                ...PaymentConfirmTypes.walletError,
+                message: "Apple Pay is not supported in Simulated Environment",
+              }->HyperModule.stringifiedResStatus,
+            )
           }, 2000)->ignore
         | Failed(error_message) =>
           setLoading(FillingDetails)
           showAlert(~errorType="error", ~message=error_message)
+          HyperModule.hyperModule.notifyWidgetPaymentResult(
+            nativeProp.rootTag,
+            {
+              ...PaymentConfirmTypes.walletError,
+              message: error_message,
+            }->HyperModule.stringifiedResStatus,
+          )
         }
       | None =>
         setLoading(FillingDetails)
         showAlert(~errorType="error", ~message="Technical Error")
+        HyperModule.hyperModule.notifyWidgetPaymentResult(
+          nativeProp.rootTag,
+          PaymentConfirmTypes.defaultConfirmError->HyperModule.stringifiedResStatus,
+        )
       }
     | None =>
       setLoading(FillingDetails)
       showAlert(~errorType="error", ~message="Technical Error")
+      HyperModule.hyperModule.notifyWidgetPaymentResult(
+        nativeProp.rootTag,
+        PaymentConfirmTypes.defaultConfirmError->HyperModule.stringifiedResStatus,
+      )
     }
   }
 

--- a/src/types/AllApiDataTypes/PaymentConfirmTypes.res
+++ b/src/types/AllApiDataTypes/PaymentConfirmTypes.res
@@ -104,6 +104,14 @@ let formValidationError = {
   code: "form_validation_failed",
   message: "Payment form has validation errors. Please correct them and try again.",
 }
+
+let walletError = {
+  type_: "wallet_error",
+  status: "wallet_failed",
+  code: "wallet_error",
+  message: "An error occurred with the wallet during payment confirmation. Please try again or use a different payment method.",
+}
+
 let getACH_bank_transfer = (data: option<bank_transfer_steps_and_charges_details>) => {
   switch data {
   | Some(data) => data.ach_credit_transfer


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

Fixed missing widget notifications for error/cancel states in payment confirmation. Previously, when payments failed or were cancelled in SavedPaymentSheet, the
  notifyWidgetPaymentResult was only called on success, leaving widgets unaware of failure states.

  Added notifyWidgetPaymentResult calls for:
  - Google Pay: Cancelled, Failed, and None (technical error) states
  - Apple Pay: Cancelled, Simulated, Failed, and None (technical error) states

  Also introduced a new walletError type in PaymentConfirmTypes to properly categorize wallet-related failures.

---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [x] Android 
- [x] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [x] Tested in Android app
- [x] Tested in iOS app


Notes: Widget error notification coverage for saved payment methods (Google Pay & Apple Pay)

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
