### PR TITLE
feat: add alwaysSendCustomerAcceptance prop

### DIFF
--- a/src/components/dynamic/DynamicFields.res
+++ b/src/components/dynamic/DynamicFields.res
@@ -46,12 +46,13 @@ let make = (
     <UIUtils.RenderIf condition={isCardPayment && !isGiftCardPayment && fields->Array.length > 0}>
       {switch (
         nativeProp.configuration.displaySavedPaymentMethodsCheckbox,
+        nativeProp.configuration.alwaysSendCustomerAcceptance,
         customerPaymentMethodData->Option.map(data => data.is_guest_customer)->Option.getOr(true),
         accountPaymentMethodData
         ->Option.map(accountPaymentMethods => accountPaymentMethods.payment_type)
         ->Option.getOr(NORMAL),
       ) {
-      | (true, false, NEW_MANDATE | NORMAL) =>
+      | (true, false, false, NEW_MANDATE | NORMAL) =>
         <ReactNative.View
           style={ReactNative.Style.s({paddingHorizontal: 2.->ReactNative.Style.dp})}>
           <ClickableTextElement

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -400,10 +400,13 @@ let make = (
     None
   }, [selectedToken])
 
+  // NOTE: To introduce a new component that shows Terms and conditions.
+  // Terms list that proceeding with payment using card/ saved card/ wallet would save the payment method details
   let showDisclaimer =
     accountPaymentMethodData
     ->Option.map(accountPaymentMethods => accountPaymentMethods.payment_type)
-    ->Option.getOr(NORMAL) !== NORMAL
+    ->Option.getOr(NORMAL) !== NORMAL &&
+    !nativeProp.configuration.alwaysSendCustomerAcceptance
 
   let handlePress = _ => {
     switch (

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -226,6 +226,7 @@ type configurationType = {
   allowsPaymentMethodsRequiringShippingAddress: bool,
   displaySavedPaymentMethodsCheckbox: bool,
   displaySavedPaymentMethods: bool,
+  alwaysSendCustomerAcceptance: bool,
   placeholder: placeholder,
   defaultView: bool,
   netceteraSDKApiKey: option<string>,
@@ -838,6 +839,11 @@ let parseConfigurationDict = (configObj, from) => {
       true,
     ),
     displaySavedPaymentMethods: getBool(configObj, "displaySavedPaymentMethods", true),
+    alwaysSendCustomerAcceptance: getBool(
+      configObj,
+      "alwaysSendCustomerAcceptance",
+      false,
+    ),
     defaultView: getBool(configObj, "defaultView", false),
     netceteraSDKApiKey: getOptionString(configObj, "netceteraSDKApiKey"),
     placeholder: {

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -46,7 +46,8 @@ let generateCardConfirmBody = (
     payment_type: ?payment_type_str,
     customer_acceptance: ?(
       payment_token->Option.isNone &&
-      ((isNicknameSelected && isMandate) ||
+      (nativeProp.configuration.alwaysSendCustomerAcceptance ||
+      (isNicknameSelected && isMandate) ||
       isMandate && !isNicknameSelected && !(isSaveCardCheckboxVisible->Option.getOr(false)) ||
       payment_type === NORMAL && isNicknameSelected ||
       payment_type === SETUP_MANDATE) &&


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

### - `alwaysSendCustomerAcceptance` prop
- boolean option (default: `false`)
- Always sends `customer_acceptance` in payment requests for **non-guest customers**
- Hides the save card checkbox in SavedPaymentSheet and PaymentSheet 
- If `displaySavedPaymentMethodsCheckbox: true` and `alwaysSendCustomerAcceptance: true`, the **checkbox stays hidden**.

---

## SCREENSHOTS
| amount | setup_future_usage | alwaysSendCustomerAcceptance | user_action                                                  | customer_acceptance                      | screenshot |
|--------|--------------------|------------------------------|--------------------------------------------------------------|------------------------------------------|------------|
| 10     | on_session         | false                        | CHECKBOX NOT SELECTED                                        | NOT SENT                                 |            |
| 10     | on_session         | false                        | CHECKBOX SELECTED                                            | SENT                                     |            |
| 0      | off_session        | false                        | CHECKBOX NOT DISPLAYED                                       | SENT                                     |            |
| 10     | off_session        | false                        | [CHECKBOX DISPLAYED, SAVED PAYMENT SCREEN DISPLAYED]         | SENT AS PER CHECKBOX SELECTION           | <img width="914" height="1624" alt="image" src="https://github.com/user-attachments/assets/96fb4693-d05d-4939-acb9-c60bd880b009" />  |
| 10     | off_session        | true                         | [CHECKBOX NOT DISPLAYED, SAVED PAYMENT SCREEN DISPLAYED]     | SENT, NICKNAME INPUT FIELD NOT DISPLAYED | <img width="926" height="1752" alt="image" src="https://github.com/user-attachments/assets/3b0435a3-aa71-4472-8c15-61587c0ed47c" />  |
| 10     | on_session         | true                         | [CHECKBOX NOT DISPLAYED, SAVED PAYMENT SCREEN DISPLAYED]     | SENT, NICKNAME INPUT FIELD NOT DISPLAYED | <img width="924" height="1698" alt="image" src="https://github.com/user-attachments/assets/8d0eed88-6330-4983-bcf0-dc9e04ff5132" />  |
| 0      | off_session        | true                         | [CHECKBOX NOT DISPLAYED, SAVED PAYMENT SCREEN NOT DISPLAYED] | SENT, NICKNAME INPUT FIELD DISPLAYED     | <img width="926" height="1722" alt="image" src="https://github.com/user-attachments/assets/97861051-d745-46c9-bc64-32b83b4b7a50" /> |
| 10     | on_session         | true                         | [GUEST_CUSTOMER,   CHECKBOX NOT DISPLAYED,  SAVED PAYMENT SCREEN NOT DISPLAYED ] | NOT SENT                                 |            |


## Affected Area & Impact

<!-- Select all that apply -->

- [X] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any): https://github.com/juspay/hyperswitch-sdk-android/pull/118**  
**iOS PR / status (if any): https://github.com/juspay/hyperswitch-sdk-ios/pull/87**
**Shared Codebase PR / status (if any):**



## Testing

- [X] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app
- [X] Tested in web app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
