### PR TITLE
feat: implement wallet confirmation callback for payment flows

### DIFF
--- a/src/components/dynamic/ButtonElement.res
+++ b/src/components/dynamic/ButtonElement.res
@@ -22,6 +22,7 @@ let make = (
   } = ThemebasedStyle.useThemeBasedStyle()
 
   let handleWalletPayments = ButtonHook.useProcessPayButtonResult()
+  let handleWalletConfirmCallback = WalletConfirmCallback.useWalletConfirmCallback()
   let {getRequiredFieldsForButton, setInitialValueCountry} = React.useContext(
     DynamicFieldsContext.dynamicFieldsContext,
   )
@@ -198,113 +199,121 @@ let make = (
       (),
     )
 
-    switch paymentMethodData.payment_method_type_wallet {
-    | GOOGLE_PAY =>
-      HyperModule.launchGPay(
-        WalletType.getGpayTokenStringified(
-          ~obj=sessionObject,
-          ~appEnv=nativeProp.hyperswitchConfig.environment,
-        ),
-        confirmGPay,
-      )
-    | PAYPAL =>
-      if (
-        sessionObject.session_token !== "" &&
-        WebKit.platform == #android &&
-        PaypalModule.payPalModule->Option.isSome
-      ) {
-        PaypalModule.launchPayPal(sessionObject.session_token, confirmPayPal)
-      } else if (
-        paymentMethodData.payment_experience
-        ->Array.find(exp => exp.payment_experience_type_decode == REDIRECT_TO_URL)
-        ->Option.isSome
-      ) {
-        let redirectData = []->Dict.fromArray->JSON.Encode.object
-        let payment_method_data = [
-          (
-            paymentMethodData.payment_method_str,
-            [(paymentMethodData.payment_method_type ++ "_redirect", redirectData)]
-            ->Dict.fromArray
-            ->JSON.Encode.object,
+    let doProceed = () => {
+      switch paymentMethodData.payment_method_type_wallet {
+      | GOOGLE_PAY =>
+        HyperModule.launchGPay(
+          WalletType.getGpayTokenStringified(
+            ~obj=sessionObject,
+            ~appEnv=nativeProp.hyperswitchConfig.environment,
           ),
-        ]->Dict.fromArray
-
-        processWalletData(payment_method_data)
-      } else {
-        setLoading(FillingDetails)
-        showAlert(~errorType="warning", ~message="Payment Method Unavailable")
-      }
-    | APPLE_PAY =>
-      if (
-        sessionObject.session_token_data == JSON.Encode.null ||
-          sessionObject.payment_request_data == JSON.Encode.null
-      ) {
-        setLoading(FillingDetails)
-        showAlert(~errorType="warning", ~message="Waiting for Sessions API")
-      } else {
-        logger(
-          ~logType=DEBUG,
-          ~value=paymentMethodData.payment_method_type,
-          ~category=USER_EVENT,
-          ~paymentMethod=paymentMethodData.payment_method_type,
-          ~eventName=APPLE_PAY_STARTED_FROM_JS,
-          ~paymentExperience=paymentMethodData.payment_experience,
-          (),
+          confirmGPay,
         )
+      | PAYPAL =>
+        if (
+          sessionObject.session_token !== "" &&
+          WebKit.platform == #android &&
+          PaypalModule.payPalModule->Option.isSome
+        ) {
+          PaypalModule.launchPayPal(sessionObject.session_token, confirmPayPal)
+        } else if (
+          paymentMethodData.payment_experience
+          ->Array.find(exp => exp.payment_experience_type_decode == REDIRECT_TO_URL)
+          ->Option.isSome
+        ) {
+          let redirectData = []->Dict.fromArray->JSON.Encode.object
+          let payment_method_data = [
+            (
+              paymentMethodData.payment_method_str,
+              [(paymentMethodData.payment_method_type ++ "_redirect", redirectData)]
+              ->Dict.fromArray
+              ->JSON.Encode.object,
+            ),
+          ]->Dict.fromArray
 
-        let timerId = setTimeout(() => {
+          processWalletData(payment_method_data)
+        } else {
           setLoading(FillingDetails)
-          showAlert(~errorType="warning", ~message="Apple Pay Error, Please try again")
+          showAlert(~errorType="warning", ~message="Payment Method Unavailable")
+        }
+      | APPLE_PAY =>
+        if (
+          sessionObject.session_token_data == JSON.Encode.null ||
+            sessionObject.payment_request_data == JSON.Encode.null
+        ) {
+          setLoading(FillingDetails)
+          showAlert(~errorType="warning", ~message="Waiting for Sessions API")
+        } else {
           logger(
             ~logType=DEBUG,
             ~value=paymentMethodData.payment_method_type,
             ~category=USER_EVENT,
             ~paymentMethod=paymentMethodData.payment_method_type,
-            ~eventName=APPLE_PAY_PRESENT_FAIL_FROM_NATIVE,
+            ~eventName=APPLE_PAY_STARTED_FROM_JS,
             ~paymentExperience=paymentMethodData.payment_experience,
             (),
           )
-        }, 5000)
 
-        HyperModule.launchApplePay(
-          [
-            ("session_token_data", sessionObject.session_token_data),
-            ("payment_request_data", sessionObject.payment_request_data),
-          ]
-          ->Dict.fromArray
-          ->JSON.Encode.object
-          ->JSON.stringify,
-          confirmApplePay,
-          _ => {
+          let timerId = setTimeout(() => {
+            setLoading(FillingDetails)
+            showAlert(~errorType="warning", ~message="Apple Pay Error, Please try again")
             logger(
               ~logType=DEBUG,
               ~value=paymentMethodData.payment_method_type,
               ~category=USER_EVENT,
               ~paymentMethod=paymentMethodData.payment_method_type,
-              ~eventName=APPLE_PAY_BRIDGE_SUCCESS,
+              ~eventName=APPLE_PAY_PRESENT_FAIL_FROM_NATIVE,
               ~paymentExperience=paymentMethodData.payment_experience,
               (),
             )
-          },
-          _ => {
-            clearTimeout(timerId)
-          },
+          }, 5000)
+
+          HyperModule.launchApplePay(
+            [
+              ("session_token_data", sessionObject.session_token_data),
+              ("payment_request_data", sessionObject.payment_request_data),
+            ]
+            ->Dict.fromArray
+            ->JSON.Encode.object
+            ->JSON.stringify,
+            confirmApplePay,
+            _ => {
+              logger(
+                ~logType=DEBUG,
+                ~value=paymentMethodData.payment_method_type,
+                ~category=USER_EVENT,
+                ~paymentMethod=paymentMethodData.payment_method_type,
+                ~eventName=APPLE_PAY_BRIDGE_SUCCESS,
+                ~paymentExperience=paymentMethodData.payment_experience,
+                (),
+              )
+            },
+            _ => {
+              clearTimeout(timerId)
+            },
+          )
+        }
+      | SAMSUNG_PAY =>
+        logger(
+          ~logType=INFO,
+          ~value="Samsung Pay Button Clicked",
+          ~category=USER_EVENT,
+          ~eventName=SAMSUNG_PAY,
+          (),
         )
-      }
-    | SAMSUNG_PAY =>
-      logger(
-        ~logType=INFO,
-        ~value="Samsung Pay Button Clicked",
-        ~category=USER_EVENT,
-        ~eventName=SAMSUNG_PAY,
-        (),
-      )
-    // SamsungPayModule.presentSamsungPayPaymentSheet(confirmSamsungPay)
-    | _ => {
-        setLoading(FillingDetails)
-        processWalletData(Dict.make(), ~useIntentData=true)
+      // SamsungPayModule.presentSamsungPayPaymentSheet(confirmSamsungPay)
+      | _ => {
+          setLoading(FillingDetails)
+          processWalletData(Dict.make(), ~useIntentData=true)
+        }
       }
     }
+    let doAbort = () => {
+      setLoading(FillingDetails)
+    }
+
+    let walletTypeStr = paymentMethodData.payment_method_type_wallet->SdkTypes.walletTypeToStrMapper
+    handleWalletConfirmCallback(walletTypeStr, doProceed, doAbort)->ignore
   }
 
   React.useEffect1(() => {

--- a/src/components/modules/HyperModule.res
+++ b/src/components/modules/HyperModule.res
@@ -15,7 +15,7 @@ type hyperModule = {
   notifyWidgetPaymentResult: (int, string) => unit,
   emitPaymentEvent: (int, string, JSON.t) => unit,
   onUpdateIntentEvent: (int, string, string) => unit,
-  onPaymentConfirmButtonCallback: (int, string, bool => unit) => unit,
+  onPaymentConfirmButtonClick: (int, string, bool => unit) => unit,
 }
 
 let getFunctionFromModule = (dict: Dict.t<'a>, key: string, default) => {
@@ -61,9 +61,9 @@ let hyperModule = {
   ) => ()),
   emitPaymentEvent: getFunctionFromModule(hyperModuleDict, "emitPaymentEvent", (_, _, _) => ()),
   onUpdateIntentEvent: getFunctionFromModule(hyperModuleDict, "onUpdateIntentEvent", (_, _, _) => ()),
-  onPaymentConfirmButtonCallback: getFunctionFromModule(
+  onPaymentConfirmButtonClick: getFunctionFromModule(
     hyperModuleDict,
-    "onPaymentConfirmButtonCallback",
+    "onPaymentConfirmButtonClick",
     (_, _, _) => (),
   ),
 }
@@ -192,6 +192,6 @@ let updateWidgetHeight = (height: int) => {
   hyperModule.updateWidgetHeight(height)
 }
 
-let onPaymentConfirmButtonCallback = (rootTag: int, payload: JSON.t, callback: bool => unit) => {
-  hyperModule.onPaymentConfirmButtonCallback(rootTag, payload->JSON.stringify, callback)
+let onPaymentConfirmButtonClick = (rootTag: int, payload: JSON.t, callback: bool => unit) => {
+  hyperModule.onPaymentConfirmButtonClick(rootTag, payload->JSON.stringify, callback)
 }

--- a/src/components/modules/HyperModule.res
+++ b/src/components/modules/HyperModule.res
@@ -15,6 +15,7 @@ type hyperModule = {
   notifyWidgetPaymentResult: (int, string) => unit,
   emitPaymentEvent: (int, string, JSON.t) => unit,
   onUpdateIntentEvent: (int, string, string) => unit,
+  onPaymentConfirmButtonCallback: (int, string, bool => unit) => unit,
 }
 
 let getFunctionFromModule = (dict: Dict.t<'a>, key: string, default) => {
@@ -59,8 +60,11 @@ let hyperModule = {
     _,
   ) => ()),
   emitPaymentEvent: getFunctionFromModule(hyperModuleDict, "emitPaymentEvent", (_, _, _) => ()),
-  onUpdateIntentEvent: getFunctionFromModule(hyperModuleDict, "onUpdateIntentEvent", (_, _, _) =>
-    ()
+  onUpdateIntentEvent: getFunctionFromModule(hyperModuleDict, "onUpdateIntentEvent", (_, _, _) => ()),
+  onPaymentConfirmButtonCallback: getFunctionFromModule(
+    hyperModuleDict,
+    "onPaymentConfirmButtonCallback",
+    (_, _, _) => (),
   ),
 }
 
@@ -186,4 +190,8 @@ let launchWidgetPaymentSheet = (requestObj: string, callback) => {
 
 let updateWidgetHeight = (height: int) => {
   hyperModule.updateWidgetHeight(height)
+}
+
+let onPaymentConfirmButtonCallback = (rootTag: int, payload: JSON.t, callback: bool => unit) => {
+  hyperModule.onPaymentConfirmButtonCallback(rootTag, payload->JSON.stringify, callback)
 }

--- a/src/components/modules/HyperModules/spec/TurboNativeSpec.ts
+++ b/src/components/modules/HyperModules/spec/TurboNativeSpec.ts
@@ -8,25 +8,13 @@ import {TurboModuleRegistry} from 'react-native';
 export interface Spec extends TurboModule {
   sendMessageToNative(message: string): void;
 
-  launchApplePay(
-    requestObj: string,
-    callback: (result: Object) => void,
-  ): void;
+  launchApplePay(requestObj: string, callback: (result: Object) => void): void;
 
-  startApplePay(
-    requestObj: string,
-    callback: (result: Object) => void,
-  ): void;
+  startApplePay(requestObj: string, callback: (result: Object) => void): void;
 
-  presentApplePay(
-    requestObj: string,
-    callback: (result: Object) => void,
-  ): void;
+  presentApplePay(requestObj: string, callback: (result: Object) => void): void;
 
-  launchGPay(
-    requestObj: string,
-    callback: (result: Object) => void,
-  ): void;
+  launchGPay(requestObj: string, callback: (result: Object) => void): void;
 
   exitPaymentsheet(rootTag: number, result: string, reset: boolean): void;
 
@@ -40,7 +28,12 @@ export interface Spec extends TurboModule {
 
   exitCardForm(result: string): void;
 
-  exitWidgetPaymentsheet(rootTag: number, widgetId: string, result: string, reset: boolean): void;
+  exitWidgetPaymentsheet(
+    rootTag: number,
+    widgetId: string,
+    result: string,
+    reset: boolean,
+  ): void;
 
   launchWidgetPaymentSheet(
     requestObj: string,
@@ -50,9 +43,14 @@ export interface Spec extends TurboModule {
   updateWidgetHeight(height: number): void;
 
   onAddPaymentMethod(data: string): void;
-  
+
   emitPaymentEvent(eventType: string, payload: Object): void;
 
+  onPaymentConfirmButtonCallback(
+    rootTag: number,
+    payload: string,
+    callback: (shouldProceed: boolean) => void,
+  ): void;
 }
 
 /**

--- a/src/hooks/WalletConfirmCallback.res
+++ b/src/hooks/WalletConfirmCallback.res
@@ -1,5 +1,5 @@
 // Hook to gate wallet payment flows behind a native callback.
-// Notifies native via onPaymentConfirmButtonCallback and waits for
+// Notifies native via onPaymentConfirmButtonClick and waits for
 // native to invoke the callback with a boolean.
 // true  => proceed with wallet launch
 // false => abort (reset loading state)
@@ -18,7 +18,7 @@ let useWalletConfirmCallback = () => {
         ->Dict.fromArray
         ->JSON.Encode.object
 
-      HyperModule.onPaymentConfirmButtonCallback(
+      HyperModule.onPaymentConfirmButtonClick(
         nativeProp.rootTag,
         payload,
         shouldProceed => {

--- a/src/hooks/WalletConfirmCallback.res
+++ b/src/hooks/WalletConfirmCallback.res
@@ -1,0 +1,35 @@
+// Hook to gate wallet payment flows behind a native callback.
+// Notifies native via onPaymentConfirmButtonCallback and waits for
+// native to invoke the callback with a boolean.
+// true  => proceed with wallet launch
+// false => abort (reset loading state)
+// A pendingRef prevents second taps while waiting.
+
+open SdkTypes
+
+let pendingRef = React.useRef(false)
+let useWalletConfirmCallback = () => {
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+  (paymentMethodType: string, onProceed: unit => unit, onAbort: unit => unit) => {
+    if !pendingRef.current {
+      pendingRef.current = true
+      let payload =
+        [("paymentMethodType", paymentMethodType->JSON.Encode.string)]
+        ->Dict.fromArray
+        ->JSON.Encode.object
+
+      HyperModule.onPaymentConfirmButtonCallback(
+        nativeProp.rootTag,
+        payload,
+        shouldProceed => {
+          pendingRef.current = false
+          if shouldProceed {
+            onProceed()
+          } else {
+            onAbort()
+          }
+        },
+      )
+    }
+  }
+}

--- a/src/hooks/useWidgetActions.res
+++ b/src/hooks/useWidgetActions.res
@@ -5,7 +5,16 @@ let useNotifyValidationFailure = () => {
 
   () => {
     switch nativeProp.sdkState {
-    | WidgetPaymentSheet | WidgetTabSheet | WidgetButtonSheet =>
+    | PaymentSheet
+    | ButtonSheet
+    | TabSheet
+    | WidgetPaymentSheet
+    | WidgetButtonSheet
+    | WidgetTabSheet
+    | HostedCheckout
+    | CardWidget
+    | ExpressCheckoutWidget
+    | PaymentMethodsManagement =>
       HyperModule.hyperModule.notifyWidgetPaymentResult(
         nativeProp.rootTag,
         PaymentConfirmTypes.formValidationError->HyperModule.stringifiedResStatus,

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -31,6 +31,7 @@ let make = (
   let handleWalletPayments = ButtonHook.useProcessPayButtonResult()
   let {launchApplePay, launchGPay} = WebKit.useWebKit()
   let notifyValidationFailure = UseWidgetActions.useNotifyValidationFailure()
+  let handleWalletConfirmCallback = WalletConfirmCallback.useWalletConfirmCallback()
 
   let (errorText, setErrorText) = React.useState(_ => None)
 
@@ -410,6 +411,10 @@ let make = (
     ->Option.map(accountPaymentMethods => accountPaymentMethods.payment_type)
     ->Option.getOr(NORMAL) !== NORMAL
 
+  let onAbort = () => {
+    setLoading(FillingDetails)
+  }
+
   let handlePress = _ => {
     switch (
       selectedToken,
@@ -461,52 +466,56 @@ let make = (
               (),
             )
 
-            let timerId = setTimeout(() => {
-              setLoading(FillingDetails)
-              showAlert(~errorType="warning", ~message="Apple Pay Error, Please try again")
-              logger(
-                ~logType=DEBUG,
-                ~value="apple_pay",
-                ~category=USER_EVENT,
-                ~paymentMethod="apple_pay",
-                ~eventName=APPLE_PAY_PRESENT_FAIL_FROM_NATIVE,
-                (),
-              )
-            }, 5000)
+            let doLaunchApplePay = () => {
+              let timerId = setTimeout(() => {
+                setLoading(FillingDetails)
+                showAlert(~errorType="warning", ~message="Apple Pay Error, Please try again")
+                logger(
+                  ~logType=DEBUG,
+                  ~value="apple_pay",
+                  ~category=USER_EVENT,
+                  ~paymentMethod="apple_pay",
+                  ~eventName=APPLE_PAY_PRESENT_FAIL_FROM_NATIVE,
+                  (),
+                )
+              }, 5000)
 
-            WebKit.platform === #ios
-              ? HyperModule.launchApplePay(
-                  [
-                    ("session_token_data", sessionObject.session_token_data),
-                    ("payment_request_data", sessionObject.payment_request_data),
-                  ]
-                  ->Dict.fromArray
-                  ->JSON.Encode.object
-                  ->JSON.stringify,
-                  confirmApplePay,
-                  _ => {
-                    logger(
-                      ~logType=DEBUG,
-                      ~value="apple_pay",
-                      ~category=USER_EVENT,
-                      ~paymentMethod="apple_pay",
-                      ~eventName=APPLE_PAY_BRIDGE_SUCCESS,
-                      (),
-                    )
-                  },
-                  _ => {
-                    clearTimeout(timerId)
-                  },
-                )
-              : launchApplePay(
-                  [
-                    ("session_token_data", sessionObject.session_token_data),
-                    ("payment_request_data", sessionObject.payment_request_data),
-                  ]
-                  ->Dict.fromArray
-                  ->JSON.Encode.object
-                  ->JSON.stringify,
-                )
+              WebKit.platform === #ios
+                ? HyperModule.launchApplePay(
+                    [
+                      ("session_token_data", sessionObject.session_token_data),
+                      ("payment_request_data", sessionObject.payment_request_data),
+                    ]
+                    ->Dict.fromArray
+                    ->JSON.Encode.object
+                    ->JSON.stringify,
+                    confirmApplePay,
+                    _ => {
+                      logger(
+                        ~logType=DEBUG,
+                        ~value="apple_pay",
+                        ~category=USER_EVENT,
+                        ~paymentMethod="apple_pay",
+                        ~eventName=APPLE_PAY_BRIDGE_SUCCESS,
+                        (),
+                      )
+                    },
+                    _ => {
+                      clearTimeout(timerId)
+                    },
+                  )
+                : launchApplePay(
+                    [
+                      ("session_token_data", sessionObject.session_token_data),
+                      ("payment_request_data", sessionObject.payment_request_data),
+                    ]
+                    ->Dict.fromArray
+                    ->JSON.Encode.object
+                    ->JSON.stringify,
+                  )
+            }
+
+            handleWalletConfirmCallback("apple_pay", doLaunchApplePay, onAbort)->ignore
           }
 
         | GOOGLE_PAY =>
@@ -517,21 +526,33 @@ let make = (
             ->Option.getOr(SessionsType.defaultToken)
           | _ => SessionsType.defaultToken
           }
-          WebKit.platform === #android
-            ? HyperModule.launchGPay(
-                WalletType.getGpayTokenStringified(
-                  ~obj=sessionObject,
-                  ~appEnv=nativeProp.hyperswitchConfig.environment,
-                ),
-                confirmGPay,
-              )
-            : launchGPay(
-                WalletType.getGpayTokenStringified(
-                  ~obj=sessionObject,
-                  ~appEnv=nativeProp.hyperswitchConfig.environment,
-                ),
-              )
-        | _ => processRequestSaved(token)
+          let doLaunchGPay = () => {
+            WebKit.platform === #android
+              ? HyperModule.launchGPay(
+                  WalletType.getGpayTokenStringified(
+                    ~obj=sessionObject,
+                    ~appEnv=nativeProp.hyperswitchConfig.environment,
+                  ),
+                  confirmGPay,
+                )
+              : launchGPay(
+                  WalletType.getGpayTokenStringified(
+                    ~obj=sessionObject,
+                    ~appEnv=nativeProp.hyperswitchConfig.environment,
+                  ),
+                )
+          }
+          handleWalletConfirmCallback("google_pay", doLaunchGPay, onAbort)->ignore
+        | PAYPAL =>
+          handleWalletConfirmCallback("paypal", () => processRequestSaved(token), onAbort)->ignore
+        | SAMSUNG_PAY =>
+          handleWalletConfirmCallback(
+            "samsung_pay",
+            () => processRequestSaved(token),
+            onAbort,
+          )->ignore
+        | _ =>
+          handleWalletConfirmCallback("wallet", () => processRequestSaved(token), onAbort)->ignore
         }
       | _ => processRequestSaved(token)
       }

--- a/src/types/NativeModulesType.res
+++ b/src/types/NativeModulesType.res
@@ -16,7 +16,7 @@ type hyperModule = {
   updateWidgetHeight: int => unit,
   emitPaymentEvent: (string, string, JSON.t) => unit,
   onUpdateIntentEvent: (int, string, string) => unit,
-  onPaymentConfirmButtonCallback: (int, string, bool => unit) => unit,
+  onPaymentConfirmButtonClick: (int, string, bool => unit) => unit,
 }
 
 type useExitPaymentsheetReturnType = {

--- a/src/types/NativeModulesType.res
+++ b/src/types/NativeModulesType.res
@@ -16,6 +16,7 @@ type hyperModule = {
   updateWidgetHeight: int => unit,
   emitPaymentEvent: (string, string, JSON.t) => unit,
   onUpdateIntentEvent: (int, string, string) => unit,
+  onPaymentConfirmButtonCallback: (int, string, bool => unit) => unit,
 }
 
 type useExitPaymentsheetReturnType = {


### PR DESCRIPTION
This pull request introduces a new wallet confirmation flow that allows native code to intercept and approve or reject wallet payment attempts before proceeding. The implementation adds a hook to gate wallet payment launches behind a native callback, updates the payment button and saved payment sheet components to use this hook, and extends the native module interfaces to support the new callback. Additional minor improvements and refactoring are included.

**Wallet Confirmation Flow Integration:**

* Added a new `useWalletConfirmCallback` hook in `WalletConfirmCallback.res` that notifies native code via `onPaymentConfirmButtonCallback` and waits for approval before launching wallet payments, preventing multiple taps while waiting for a response.
* Updated `ButtonElement.res` and `SavedPaymentSheet.res` to use the new wallet confirmation hook for all wallet payment methods (Apple Pay, Google Pay, PayPal, Samsung Pay, and others), ensuring wallet launches are gated by native approval and providing abort logic to reset loading state if denied. [[1]](diffhunk://#diff-6a55f34dbac9214db6c650b45b74a666ac7faddf0ce026fa42a4dfcf60432ce7R25) [[2]](diffhunk://#diff-6a55f34dbac9214db6c650b45b74a666ac7faddf0ce026fa42a4dfcf60432ce7R202) [[3]](diffhunk://#diff-6a55f34dbac9214db6c650b45b74a666ac7faddf0ce026fa42a4dfcf60432ce7R311-R317) [[4]](diffhunk://#diff-aaee2563afb60305b4da027f42c4ef30503d7d7d5adb44d53674153fcbf0203bR34) [[5]](diffhunk://#diff-aaee2563afb60305b4da027f42c4ef30503d7d7d5adb44d53674153fcbf0203bR414-R417) [[6]](diffhunk://#diff-aaee2563afb60305b4da027f42c4ef30503d7d7d5adb44d53674153fcbf0203bR469) [[7]](diffhunk://#diff-aaee2563afb60305b4da027f42c4ef30503d7d7d5adb44d53674153fcbf0203bR518-R520) [[8]](diffhunk://#diff-aaee2563afb60305b4da027f42c4ef30503d7d7d5adb44d53674153fcbf0203bR529) [[9]](diffhunk://#diff-aaee2563afb60305b4da027f42c4ef30503d7d7d5adb44d53674153fcbf0203bL534-R555)

**Native Module Interface Updates:**

* Extended the `HyperModule` and related types (`NativeModulesType.res`, `HyperModule.res`, and TurboModule spec) to add the `onPaymentConfirmButtonCallback` method, allowing native code to intercept wallet payment attempts and respond with approval or rejection. [[1]](diffhunk://#diff-2f5f60ba090e0a7852120d684fdf320b7ee637d519cd2568098092605da413d2R18) [[2]](diffhunk://#diff-2f5f60ba090e0a7852120d684fdf320b7ee637d519cd2568098092605da413d2L62-R67) [[3]](diffhunk://#diff-2f5f60ba090e0a7852120d684fdf320b7ee637d519cd2568098092605da413d2R194-R197) [[4]](diffhunk://#diff-4e41bf9d1ff308118173832f6c0febc08410482597f806c1679d7a686fc1ca58R19) [[5]](diffhunk://#diff-5faadb92bc3810f8cab9fb5d68e04874d9c0c0b9489e0f35b0491618900a3fcbR49-R53)

**Minor Improvements and Refactoring:**

* Improved formatting and consistency in the TurboModule spec and related files. [[1]](diffhunk://#diff-5faadb92bc3810f8cab9fb5d68e04874d9c0c0b9489e0f35b0491618900a3fcbL11-R17) [[2]](diffhunk://#diff-5faadb92bc3810f8cab9fb5d68e04874d9c0c0b9489e0f35b0491618900a3fcbL43-R36)
* Updated `useNotifyValidationFailure` to handle additional widget states for validation error notification.## Type of Change

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

<!-- Brief description of the change -->

---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [ ] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [ ] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
