### PR TITLE
fix: respect displaySavedPaymentMethods in accordion view

### DIFF
--- a/src/hooks/AllApiDataModifier.res
+++ b/src/hooks/AllApiDataModifier.res
@@ -24,9 +24,11 @@ let useAccountPaymentMethodModifier = () => {
   React.useMemo3(() => {
     let groupingBehavior = nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.groupingBehavior
 
-    // Show a merged "Saved" tab only when displayInSeparateScreen=false AND groupByPaymentMethods=false
+    // Show a merged "Saved" tab only when displaySavedPaymentMethods=true AND displayInSeparateScreen=false AND groupByPaymentMethods=false
     let showMergedSavedTab =
-      !groupingBehavior.displayInSeparateScreen && !groupingBehavior.groupByPaymentMethods
+      nativeProp.configuration.displaySavedPaymentMethods &&
+      !groupingBehavior.displayInSeparateScreen &&
+      !groupingBehavior.groupByPaymentMethods
 
     let (initialTabArr, initialElementArr) = if showMergedSavedTab {
       switch customerPaymentMethodData {


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why
- The merged "Saved" accordion tab was added based only on groupingBehavior, ignoring displaySavedPaymentMethods. As a result, saved cards still rendered inside the accordion when displayInSeparateScreen=false even though the merchant had turned saved methods off. Gate showMergedSavedTab on displaySavedPaymentMethods so the separate-screen and accordion paths behave consistently.

<!-- Brief description of the change -->

---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [x] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [x] Tested in consuming Android app
- [ ] Tested in consuming iOS app
