### PR TITLE
feat: added wpg DDC with webView

### DIFF
--- a/src/components/modules/HyperModule.res
+++ b/src/components/modules/HyperModule.res
@@ -16,7 +16,7 @@ type hyperModule = {
   emitPaymentEvent: (int, string, JSON.t) => unit,
   onUpdateIntentEvent: (int, string, string) => unit,
   onPaymentConfirmButtonClick: (int, string, bool => unit) => unit,
-  openDDCWebView: (string, int, string => unit) => unit,
+  openIframeBridge: (string, int, string => unit) => unit,
 }
 
 let getFunctionFromModule = (dict: Dict.t<'a>, key: string, default) => {
@@ -69,7 +69,7 @@ let hyperModule = {
     "onPaymentConfirmButtonClick",
     (_, _, _) => (),
   ),
-  openDDCWebView: getFunctionFromModule(hyperModuleDict, "openDDCWebView", (_, _, _) => ()),
+  openIframeBridge: getFunctionFromModule(hyperModuleDict, "openIframeBridge", (_, _, _) => ()),
 }
 
 let sendMessageToNative = str => {
@@ -201,6 +201,6 @@ let onPaymentConfirmButtonClick = (_: int, _: JSON.t, callback: bool => unit) =>
   // hyperModule.onPaymentConfirmButtonClick(rootTag, payload->JSON.stringify, callback)
 }
 
-let openDDCWebView = (url: string, timeoutMs: int, callback: string => unit) => {
-  hyperModule.openDDCWebView(url, timeoutMs, callback)
+let openIframeBridge = (url: string, timeoutMs: int, callback: string => unit) => {
+  hyperModule.openIframeBridge(url, timeoutMs, callback)
 }

--- a/src/components/modules/HyperModule.res
+++ b/src/components/modules/HyperModule.res
@@ -16,6 +16,7 @@ type hyperModule = {
   emitPaymentEvent: (int, string, JSON.t) => unit,
   onUpdateIntentEvent: (int, string, string) => unit,
   onPaymentConfirmButtonClick: (int, string, bool => unit) => unit,
+  openDDCWebView: (string, int, string => unit) => unit,
 }
 
 let getFunctionFromModule = (dict: Dict.t<'a>, key: string, default) => {
@@ -68,6 +69,7 @@ let hyperModule = {
     "onPaymentConfirmButtonClick",
     (_, _, _) => (),
   ),
+  openDDCWebView: getFunctionFromModule(hyperModuleDict, "openDDCWebView", (_, _, _) => ()),
 }
 
 let sendMessageToNative = str => {
@@ -197,4 +199,8 @@ let updateWidgetHeight = (height: int) => {
 let onPaymentConfirmButtonClick = (_: int, _: JSON.t, callback: bool => unit) => {
   callback(true)
   // hyperModule.onPaymentConfirmButtonClick(rootTag, payload->JSON.stringify, callback)
+}
+
+let openDDCWebView = (url: string, timeoutMs: int, callback: string => unit) => {
+  hyperModule.openDDCWebView(url, timeoutMs, callback)
 }

--- a/src/headless/HeadlessUtils.res
+++ b/src/headless/HeadlessUtils.res
@@ -373,7 +373,7 @@ let getErrorFromResponse = data => {
 
 let getBrowserInfo = (nativeProp: SdkTypes.nativeProp) => {
   let browserInfo: PaymentConfirmTypes.online = {
-    user_agent: ?nativeProp.sdkParams.userAgent,
+    user_agent: PaymentUtils.resolveUserAgent(~nativeProp),
     accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
     language: LocaleDataType.localeTypeToString(nativeProp.configuration.locale),
     color_depth: 32,

--- a/src/headless/HeadlessUtils.res
+++ b/src/headless/HeadlessUtils.res
@@ -373,7 +373,7 @@ let getErrorFromResponse = data => {
 
 let getBrowserInfo = (nativeProp: SdkTypes.nativeProp) => {
   let browserInfo: PaymentConfirmTypes.online = {
-    user_agent: PaymentUtils.resolveUserAgent(~nativeProp),
+    user_agent: Utils.resolveUserAgent(~userAgent=nativeProp.sdkParams.userAgent),
     accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
     language: LocaleDataType.localeTypeToString(nativeProp.configuration.locale),
     color_depth: 32,

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -227,6 +227,8 @@ let useRedirectHook = () => {
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
   let browserRedirectionHandler = useBrowserHook()
   let retrievePayment = useRetrieveHook()
+  let redirectionSuccessHandler = BrowserRedirectionHooks.useBrowserRedirectionSuccessHook()
+  let redirectionFailureHandler = BrowserRedirectionHooks.useBrowserRedirectionFailedHook()
   let logger = LoggerHook.useLoggerHook()
   let baseUrl = GlobalHooks.useGetBaseUrl()()
   let handleNativeThreeDS = NetceteraThreeDsHooks.useExternalThreeDs()
@@ -361,8 +363,8 @@ let useRedirectHook = () => {
       let {iframeUrl, timeoutMs} =
         (nextAction->Option.getOr(defaultNextAction)).ddc_data
         ->Option.getOr(DdcTypes.defaultDdcData)
-      HyperModule.openDDCWebView(iframeUrl, timeoutMs, redirectUrl => {
-        if redirectUrl === "" {
+      HyperModule.openIframeBridge(iframeUrl, timeoutMs, rawMessage => {
+        if rawMessage === "" {
           errorCallback(
             ~errorMessage={
               status: "failed",
@@ -374,14 +376,60 @@ let useRedirectHook = () => {
             (),
           )
         } else {
-          browserRedirectionHandler(
-            ~clientSecret,
-            ~publishableKey,
-            ~openUrl=redirectUrl,
-            ~responseCallback,
-            ~errorCallback,
-            ~paymentMethod,
-          )->ignore
+          let parsed = rawMessage->JSON.parseExn->Utils.getDictFromJson
+          let nextActionType =
+            parsed
+            ->Dict.get("next_action")
+            ->Option.flatMap(JSON.Decode.object)
+            ->Option.flatMap(d => d->Dict.get("type"))
+            ->Option.flatMap(JSON.Decode.string)
+            ->Option.getOr("")
+          let redirectUrl =
+            parsed
+            ->Dict.get("next_action")
+            ->Option.flatMap(JSON.Decode.object)
+            ->Option.flatMap(d => d->Dict.get("url"))
+            ->Option.flatMap(JSON.Decode.string)
+            ->Option.getOr("")
+          switch nextActionType {
+          | "redirect_to_url" if redirectUrl !== "" =>
+            if (
+              redirectUrl->String.includes("status=succeeded") ||
+              redirectUrl->String.includes("status=processing") ||
+              redirectUrl->String.includes("status=requires_capture") ||
+              redirectUrl->String.includes("status=partially_captured")
+            ) {
+              let _ = (async () => {
+                let s = await retrievePayment(Payment, clientSecret, publishableKey)
+                redirectionSuccessHandler(~s, ~errorCallback, ~responseCallback)
+              })()
+            } else if (
+              redirectUrl->String.includes("status=failed") ||
+              redirectUrl->String.includes("status=requires_payment_method")
+            ) {
+              redirectionFailureHandler(~errorCallback)
+            } else {
+              browserRedirectionHandler(
+                ~clientSecret,
+                ~publishableKey,
+                ~openUrl=redirectUrl,
+                ~responseCallback,
+                ~errorCallback,
+                ~paymentMethod,
+              )->ignore
+            }
+          | _ =>
+            errorCallback(
+              ~errorMessage={
+                status: "failed",
+                message: `DDC failed: invalid next action type - ${nextActionType}`,
+                type_: "invoke_ddc_error",
+                code: "ddc_failure",
+              },
+              ~closeSDK=true,
+              (),
+            )
+          }
         }
       })
     }

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -357,11 +357,41 @@ let useRedirectHook = () => {
       }
     }
 
+    let handleInvokeDDCFlow = (~nextAction) => {
+      let {iframeUrl, timeoutMs} =
+        (nextAction->Option.getOr(defaultNextAction)).ddc_data
+        ->Option.getOr(DdcTypes.defaultDdcData)
+      HyperModule.openDDCWebView(iframeUrl, timeoutMs, redirectUrl => {
+        if redirectUrl === "" {
+          errorCallback(
+            ~errorMessage={
+              status: "failed",
+              message: "DDC failed or timed out",
+              type_: "invoke_ddc_error",
+              code: "ddc_failure",
+            },
+            ~closeSDK=true,
+            (),
+          )
+        } else {
+          browserRedirectionHandler(
+            ~clientSecret,
+            ~publishableKey,
+            ~openUrl=redirectUrl,
+            ~responseCallback,
+            ~errorCallback,
+            ~paymentMethod,
+          )->ignore
+        }
+      })
+    }
+
     let handleApiRes = (~status, ~reUri, ~error: error, ~nextAction: option<nextAction>=?) => {
       switch nextAction->PaymentUtils.getActionType {
       | "three_ds_invoke" => handleInvokeThreeDSFlow(~nextAction)
       | "third_party_sdk_session_token" => handleThirdPartySDKSessionFlow(~nextAction)
       | "display_bank_transfer_information" => handleBankTransferFlow(~nextAction)
+      | "invoke_ddc" => handleInvokeDDCFlow(~nextAction)
       | _ => handleDefaultPaymentFlows(~status, ~reUri, ~error)
       }
     }

--- a/src/types/AllApiDataTypes/PaymentConfirmTypes.res
+++ b/src/types/AllApiDataTypes/PaymentConfirmTypes.res
@@ -68,6 +68,7 @@ type nextAction = {
   threeDsData?: threeDsData,
   session_token?: sessionToken,
   bank_transfer_steps_and_charges_detail?: bank_transfer_steps_and_charges_details,
+  ddc_data?: DdcTypes.ddcData,
 }
 type error = {message?: string, code?: string, type_?: string, status?: string}
 type intent = {nextAction: nextAction, status: string, error: error}
@@ -167,6 +168,16 @@ let getNextAction = (dict, str) => {
     {
       redirectToUrl: getString(json, "redirect_to_url", ""),
       type_: getString(json, "type", ""),
+      ddc_data: json
+        ->Dict.get("ddc_data")
+        ->Option.flatMap(JSON.Decode.object)
+        ->Option.map(ddcDict => {
+          DdcTypes.iframeUrl: getString(ddcDict, "iframe_url", ""),
+          timeoutMs: getOptionFloat(ddcDict, "timeout_ms")
+            ->Option.getOr(30000.)
+            ->Int.fromFloat,
+        })
+        ->Option.getOr(DdcTypes.defaultDdcData),
       threeDsData: {
         threeDsAuthorizeUrl: getString(threeDSDataDict, "three_ds_authorize_url", ""),
         threeDsAuthenticationUrl: getString(threeDSDataDict, "three_ds_authentication_url", ""),

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -47,7 +47,7 @@ let generateCardConfirmBody = (
     customer_acceptance: ?(
       payment_token->Option.isNone &&
       (nativeProp.configuration.alwaysSendCustomerAcceptance ||
-      isNicknameSelected && isMandate ||
+      (isNicknameSelected && isMandate) ||
       isMandate && !isNicknameSelected && !(isSaveCardCheckboxVisible->Option.getOr(false)) ||
       payment_type === NORMAL && isNicknameSelected ||
       payment_type === SETUP_MANDATE) &&

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -14,6 +14,19 @@ let showUseExisitingSavedCardsBtn = (
   displaySavedPaymentMethods
 }
 
+let resolveUserAgent = (~nativeProp: SdkTypes.nativeProp) =>
+  switch nativeProp.sdkParams.userAgent->Utils.getNonEmptyOption {
+  | Some(ua) => ua
+  | None =>
+    switch WebKit.platform {
+    | #ios | #iosWebView =>
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    | #android | #androidWebView =>
+      "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36"
+    | #web | #next => ""
+    }
+  }
+
 let generateCardConfirmBody = (
   ~nativeProp: SdkTypes.nativeProp,
   ~payment_method_str: string,
@@ -57,14 +70,14 @@ let generateCardConfirmBody = (
               acceptance_type: "online",
               accepted_at: Date.now()->Date.fromTime->Date.toISOString,
               online: {
-                user_agent: ?nativeProp.sdkParams.userAgent,
+                user_agent: resolveUserAgent(~nativeProp),
               },
             }
           })
         : None
     ),
     browser_info: {
-      user_agent: ?nativeProp.sdkParams.userAgent,
+      user_agent: resolveUserAgent(~nativeProp),
       accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
       language: LocaleDataType.localeTypeToString(nativeProp.configuration.locale),
       color_depth: 32,
@@ -120,7 +133,7 @@ let generateSavedCardConfirmBody = (
   ),
   payment_type: ?payment_type_str,
   browser_info: {
-    user_agent: ?nativeProp.sdkParams.userAgent,
+    user_agent: resolveUserAgent(~nativeProp),
     accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
     language: LocaleDataType.localeTypeToString(nativeProp.configuration.locale),
     color_depth: 32,

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -14,19 +14,6 @@ let showUseExisitingSavedCardsBtn = (
   displaySavedPaymentMethods
 }
 
-let resolveUserAgent = (~nativeProp: SdkTypes.nativeProp) =>
-  switch nativeProp.sdkParams.userAgent->Utils.getNonEmptyOption {
-  | Some(ua) => ua
-  | None =>
-    switch WebKit.platform {
-    | #ios | #iosWebView =>
-      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
-    | #android | #androidWebView =>
-      "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36"
-    | #web | #next => ""
-    }
-  }
-
 let generateCardConfirmBody = (
   ~nativeProp: SdkTypes.nativeProp,
   ~payment_method_str: string,
@@ -60,7 +47,7 @@ let generateCardConfirmBody = (
     customer_acceptance: ?(
       payment_token->Option.isNone &&
       (nativeProp.configuration.alwaysSendCustomerAcceptance ||
-      (isNicknameSelected && isMandate) ||
+      isNicknameSelected && isMandate ||
       isMandate && !isNicknameSelected && !(isSaveCardCheckboxVisible->Option.getOr(false)) ||
       payment_type === NORMAL && isNicknameSelected ||
       payment_type === SETUP_MANDATE) &&
@@ -70,14 +57,14 @@ let generateCardConfirmBody = (
               acceptance_type: "online",
               accepted_at: Date.now()->Date.fromTime->Date.toISOString,
               online: {
-                user_agent: resolveUserAgent(~nativeProp),
+                user_agent: Utils.resolveUserAgent(~userAgent=nativeProp.sdkParams.userAgent),
               },
             }
           })
         : None
     ),
     browser_info: {
-      user_agent: resolveUserAgent(~nativeProp),
+      user_agent: Utils.resolveUserAgent(~userAgent=nativeProp.sdkParams.userAgent),
       accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
       language: LocaleDataType.localeTypeToString(nativeProp.configuration.locale),
       color_depth: 32,
@@ -133,7 +120,7 @@ let generateSavedCardConfirmBody = (
   ),
   payment_type: ?payment_type_str,
   browser_info: {
-    user_agent: resolveUserAgent(~nativeProp),
+    user_agent: Utils.resolveUserAgent(~userAgent=nativeProp.sdkParams.userAgent),
     accept_header: "text\/html,application\/xhtml+xml,application\/xml;q=0.9,image\/webp,image\/apng,*\/*;q=0.8",
     language: LocaleDataType.localeTypeToString(nativeProp.configuration.locale),
     color_depth: 32,

--- a/src/utility/logics/Utils.res
+++ b/src/utility/logics/Utils.res
@@ -464,3 +464,16 @@ let rec pruneUnusedFieldsFromDict = (
 
   newDict
 }
+
+let resolveUserAgent = (~userAgent: option<string>) =>
+  switch userAgent->getNonEmptyOption {
+  | Some(ua) => ua
+  | None =>
+    switch WebKit.platform {
+    | #ios
+    | #iosWebView => "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    | #android
+    | #androidWebView => "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36"
+    | #web | #next => ""
+    }
+  }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

Adds support for the invoke_ddc next action type in the payment confirmation flow. When the backend returns next_action.type = "invoke_ddc", the SDK now performs Device Data Collection (DDC) via a hidden iframe before redirecting the user.
How it works

    Backend triggers DDC: After payment confirmation, if next_action.type is invoke_ddc, the SDK reads ddc_data containing iframe_url and timeout_ms from the response.
    Hidden iframe injection: A hidden iframe is created pointing to the DDC iframe_url. The iframe performs device fingerprinting/data collection in the background.
    Message-based completion: The SDK listens for a postMessage from the iframe containing a next_action with type = "redirect_to_url" and a redirect URL. On receipt, it cleans up and redirects the user.
    Timeout handling: If no response is received within timeout_ms (default 30s), the flow fails gracefully with an error message.
    Cleanup: All resources (iframe, event listener, timeout) are cleaned up on completion, failure, or timeout.



---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [x] Shared Codebase
- [x] Android 
- [x] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [ ] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
