### PR TITLE
fix: iOS safe area when branding is enabled

### DIFF
--- a/src/components/common/CustomView.res
+++ b/src/components/common/CustomView.res
@@ -128,23 +128,29 @@ module Wrapper = {
       | None => React.null
       }
 
+    let scrollViewWrapperStyle = array([s({flexShrink: 1.}), style])
+    let scrollViewContent =
+      <>
+        <ScrollView
+          contentContainerStyle=contentStyle
+          keyboardShouldPersistTaps={#handled}
+          showsVerticalScrollIndicator=false>
+          <ModalHeader onModalClose isLoading isSavedPaymentScreen />
+          children
+        </ScrollView>
+        {getStickyFooter(
+          s({
+            paddingHorizontal: sheetContentPadding->dp,
+            paddingTop: (sheetContentPadding /. 2.)->dp,
+            paddingBottom: viewPortContants.bottomInset->dp,
+          }),
+        )}
+      </>
+
     renderScrollView
-      ? <View style={array([s({flexShrink: 1.}), style])}>
-          <ScrollView
-            contentContainerStyle=contentStyle
-            keyboardShouldPersistTaps={#handled}
-            showsVerticalScrollIndicator=false>
-            <ModalHeader onModalClose isLoading isSavedPaymentScreen />
-            children
-          </ScrollView>
-          {getStickyFooter(
-            s({
-              paddingHorizontal: sheetContentPadding->dp,
-              paddingTop: (sheetContentPadding /. 2.)->dp,
-              paddingBottom: viewPortContants.bottomInset->dp,
-            }),
-          )}
-        </View>
+      ? Platform.os === #ios
+          ? <SafeAreaView style=scrollViewWrapperStyle> scrollViewContent </SafeAreaView>
+          : <View style=scrollViewWrapperStyle> scrollViewContent </View>
       : <View style={array([s({maxHeight: 100.->pct}), contentStyle, style])}>
           <ModalHeader onModalClose isLoading isSavedPaymentScreen />
           children
@@ -154,6 +160,7 @@ module Wrapper = {
               paddingBottom: viewPortContants.bottomInset->dp,
             }),
           )}
+          {Platform.os === #ios ? <SafeAreaView /> : React.null}
         </View>
   }
 }


### PR DESCRIPTION
## Type of Change

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

<!-- Brief description of the change -->

when branding is enabled iOS SDK wasn't respecting the safeArea boundary, probably because of removal of safeAreaInsets passed via native. Added SafeAreaView to Wrapper

---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->
<img width="300" alt="1" src="https://github.com/user-attachments/assets/af6ebd28-697b-448b-a214-73dbed2ae237" />
<img width="300" alt="2" src="https://github.com/user-attachments/assets/659ad82f-3dcf-4fcc-9c7c-5eccd81aaa96" />

### branding enabled


<img width="300" alt="3" src="https://github.com/user-attachments/assets/e1a8f897-430c-4874-867f-eecc8c795b4c" />
<img width="300" alt="4" src="https://github.com/user-attachments/assets/85f2cb73-5ce6-4233-8faa-1a56e5067ffc" />

---

## Affected Area & Impact

<!-- Select all that apply -->

- [X] Client Core
- [ ] Shared Codebase
- [X] Android 
- [X] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [X] JS bundle built
- [ ] Tested in Android app
- [X] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [X] Tested in consuming iOS app
