### PR TITLE
fix: text color override issue

### DIFF
--- a/src/components/elements/ClickableTextElement.res
+++ b/src/components/elements/ClickableTextElement.res
@@ -27,7 +27,13 @@ let make = (
     />
     <Space width=gap />
     <TextWrapper
-      text textType overrideStyle={Some(s({flex: 1., color: ?(isLink ? Some(linkColor) : None)}))}
+      text
+      textType
+      overrideStyle={if isLink {
+        Some(s({flex: 1., color: ?Some(linkColor)}))
+      } else {
+        Some(s({flex: 1.}))
+      }}
     />
   </CustomPressable>
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

The Text color is not applied with the passed theme instead it is defaults to the native text behaviour
---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [x] Android 
- [x] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [x] Tested in Android app
- [x] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
