### PR TITLE
refactor: cvc status event

### DIFF
--- a/src/pages/widgets/CvcWidget.res
+++ b/src/pages/widgets/CvcWidget.res
@@ -11,11 +11,7 @@ let make = () => {
   let (isFocused, setIsFocused) = React.useState(_ => false)
   let emitter = PaymentEvents.usePaymentEventEmitter()
   let localeObject = GetLocale.useGetLocalObj()
-  let {
-    component,
-    dangerColor,
-    primaryColor,
-  } = ThemebasedStyle.useThemeBasedStyle()
+  let {component, dangerColor, primaryColor} = ThemebasedStyle.useThemeBasedStyle()
 
   let cardNetwork = ""
 
@@ -35,8 +31,8 @@ let make = () => {
   let emitCvcStatusEvent = (~focused: bool, ~blur: bool) => {
     emitter.emitCvcStatus(
       ~event={
-        isCvcFocused: focused,
-        isCvcBlur: blur,
+        isCvcFocused: Some(focused),
+        isCvcBlur: Some(blur),
         isCvcEmpty,
         isCvcComplete,
       },


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

I have made `isCVCFocused` and `isCVCBlur` optional, since such events should ideally be emitted from `onFocus`/`onBlur` rather than `onChange`. For now, this is implemented only on the web side. Mobile can pick this up later when focus/blur event support is added. Currently, on web, we are not exposing these two fields.

shard code Pr: https://github.com/juspay/hyperswitch-sdk-utils/pull/75

---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [ ] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
