### PR TITLE
feat: parse new locale strings from shared-code in getLocaleStrings

### DIFF
--- a/src/hooks/S3ApiHook.res
+++ b/src/hooks/S3ApiHook.res
@@ -866,6 +866,23 @@ let getLocaleStrings: Js.Json.t => localeStrings = data => {
       ),
       statePlaceholder: Utils.getString(res, "statePlaceholder", defaultLocale.statePlaceholder),
       upiIdPlaceholder: Utils.getString(res, "upiIdPlaceholder", defaultLocale.upiIdPlaceholder),
+      loadingText: Utils.getString(res, "loadingText", defaultLocale.loadingText),
+      completeButtonText: Utils.getString(
+        res,
+        "completeButtonText",
+        defaultLocale.completeButtonText,
+      ),
+      processingText: Utils.getString(res, "processingText", defaultLocale.processingText),
+      processingRequestText: Utils.getString(
+        res,
+        "processingRequestText",
+        defaultLocale.processingRequestText,
+      ),
+      processingRequestSubtext: Utils.getString(
+        res,
+        "processingRequestSubtext",
+        defaultLocale.processingRequestSubtext,
+      ),
     }
   | None => defaultLocale
   }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What
  `shared-code` (sdk-utils) added 5 fields to the `localeStrings` record type and
  its `defaultLocale`:

  - `loadingText`
  - `completeButtonText`
  - `processingText`
  - `processingRequestText`
  - `processingRequestSubtext`

  `getLocaleStrings` in `src/hooks/S3ApiHook.res` builds this record manually,
  field-by-field, from the S3 locale JSON. Because ReScript record construction
  requires every field, the SDK failed to compile after the submodule bump:

  > Some required record fields are missing: loadingText completeButtonText
  > processingText processingRequestText processingRequestSubtext

  ## Change
  - Parse the 5 new fields in `getLocaleStrings` using the existing
    `Utils.getString(res, "<key>", defaultLocale.<key>)` pattern (keys default to
    the shared-code values when absent from the locale payload).
  - Bump submodule pointers: `shared-code`, `ios`, `android`.

  ## Notes
  - The new keys are not present in any locale JSON yet, so they currently resolve
    to `defaultLocale` — safe by design.
  - `getLocaleStringsFromJson` delegates to `getLocaleStrings`; no other site in
    `src/` constructs `localeStrings`, so this is the only required edit.
  - Follow-up (out of scope): wire `loadingText` / `processingText` into
    `CustomButton` / `ConfirmButtonAnimation`, which still hardcode those strings.

  ## Verification
  - `yarn re:build` ✅
  - `yarn re:check` (strict, 717 files) ✅


---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [ ] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
