### PR TITLE
fix: sdk-config call with auth (client_secret in query, sdkAuthorization in header

### DIFF
--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -140,33 +140,24 @@ let useSdkConfigHook = () => {
     | #android | #androidWebView => "android"
     | #web | #next => "web"
     }
-    let uri = `${baseUrl}/v1/sdk/configs/${platform}/sdk_config.json`
-
-    let clientSecret = {
-      let fromConfig = nativeProp.paymentSessionConfig.clientSecret
-      if fromConfig->String.length > 0 {
-        fromConfig
-      } else {
-        switch nativeProp.paymentSessionConfig.sdkAuthorization {
-        | Some(auth) => Utils.getSdkAuthorizationData(auth).clientSecret->Option.getOr("")
-        | None => ""
-        }
-      }
+    let clientSecret = switch nativeProp.paymentSessionConfig.sdkAuthorization {
+    | Some(auth) =>
+      Utils.getSdkAuthorizationData(auth).clientSecret->Option.getOr(
+        nativeProp.paymentSessionConfig.clientSecret,
+      )
+    | None => nativeProp.paymentSessionConfig.clientSecret
     }
-
-    let headers = Utils.getHeader(
-      ~apiKey=nativeProp.hyperswitchConfig.publishableKey,
-      ~appId=nativeProp.sdkParams.appId,
-      (),
-    )
-    if clientSecret->String.length > 0 {
-      headers->Dict.set("client-secret", clientSecret)
-    }
+    let uri = `${baseUrl}/v1/sdk/configs/${platform}/sdk_config.json?client_secret=${clientSecret}`
 
     APIUtils.fetchApiWrapper(
       ~uri,
       ~method=#GET,
-      ~headers,
+      ~headers=Utils.getHeader(
+        ~apiKey=nativeProp.hyperswitchConfig.publishableKey,
+        ~appId=nativeProp.sdkParams.appId,
+        ~sdkAuthorization=nativeProp.paymentSessionConfig.sdkAuthorization->Option.getOr(""),
+        (),
+      ),
       ~eventName=LoggerTypes.CONFIG_CALL,
       ~apiLogWrapper,
     )


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

<!-- Brief description of the change -->

Follow-up fix to #524 (superposition sdk/config consumption, already merged).

  The `GET /v1/sdk/configs/{platform}/sdk_config.json` call contract was differently from other API contracts — it set a custom `client-secret` **header** and never forwarded`sdkAuthorization`. This updates the config hook to match the agreed contract:

  - **`client_secret` → query param** (was a custom header).
  - **`sdkAuthorization` → `Authorization` header**, via the shared `Utils.getHeader`
    (the same path used by PML / sessions / retrieve calls). When `sdkAuthorization`
    is present, `getHeader` emits `Authorization: <sdkAuth>`; otherwise it falls back
    to `api-key: <publishableKey>`.

---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [ ] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
