### PR TITLE
feat: add OPPP as dimension for dynamicFields resolution

### DIFF
--- a/src/contexts/DynamicFieldsContext.res
+++ b/src/contexts/DynamicFieldsContext.res
@@ -119,6 +119,13 @@ let make = (~children) => {
     AllApiDataContextNew.allApiDataContext,
   )
   let superpositionConfig = sdkConfigData->Option.getOr(SdkConfigTypes.defaultSdkConfigValue)
+  let profile = superpositionConfig.account_config->Option.flatMap(ac => ac.profile)
+  let collectBillingDetailsFromWalletConnector = SdkConfigParser.getCollectBillingDetailsFromWalletConnector(
+    profile,
+  )
+  let collectShippingDetailsFromWalletConnector = SdkConfigParser.getCollectShippingDetailsFromWalletConnector(
+    profile,
+  )
   let getSuperpositionFinalFields = ConfigurationService.useConfigurationService(
     ~rawConfigs=superpositionConfig.raw_configs,
   )
@@ -174,8 +181,8 @@ let make = (~children) => {
       mandate_type: accountPaymentMethodData
       ->Option.map(data => data.payment_type === NORMAL ? "non_mandate" : "mandate")
       ->Option.getOr("non_mandate"),
-      collect_billing_details_from_wallet_connector: "required",
-      collect_shipping_details_from_wallet_connector: "required",
+      always_collect_billing_details_from_wallet_connector: collectBillingDetailsFromWalletConnector,
+      always_collect_shipping_details_from_wallet_connector: collectShippingDetailsFromWalletConnector,
       country: switch country {
       | Some(val) => val
       | None => defaultCountry
@@ -351,8 +358,8 @@ let make = (~children) => {
       ->Option.getOr(NORMAL) === NORMAL
         ? "non_mandate"
         : "mandate",
-      collect_billing_details_from_wallet_connector: "required",
-      collect_shipping_details_from_wallet_connector: "required",
+      always_collect_billing_details_from_wallet_connector: collectBillingDetailsFromWalletConnector,
+      always_collect_shipping_details_from_wallet_connector: collectShippingDetailsFromWalletConnector,
       country: switch country {
       | Some(val) => val
       | None => defaultCountry

--- a/src/contexts/DynamicFieldsContext.res
+++ b/src/contexts/DynamicFieldsContext.res
@@ -123,6 +123,10 @@ let make = (~children) => {
     ~rawConfigs=superpositionConfig.raw_configs,
   )
 
+  let (profile_id, processor_merchant_id, organization_id) = SdkConfigParser.getProfileContext(
+    superpositionConfig.context_used,
+  )
+
   let (sheetType, setSheetType) = React.useState(_ => ButtonSheet)
   let setSheetType = React.useCallback1(val => {
     setSheetType(_ => val)
@@ -176,6 +180,10 @@ let make = (~children) => {
       | Some(val) => val
       | None => defaultCountry
       },
+      platform: WebKit.platformGroup,
+      profile_id: ?profile_id,
+      processor_merchant_id: ?processor_merchant_id,
+      organization_id: ?organization_id,
     }
 
     switch requiredFieldsFromPML->Dict.get("payment_method_data.billing.address.country") {
@@ -349,6 +357,10 @@ let make = (~children) => {
       | Some(val) => val
       | None => defaultCountry
       },
+      platform: WebKit.platformGroup,
+      profile_id: ?profile_id,
+      processor_merchant_id: ?processor_merchant_id,
+      organization_id: ?organization_id,
     }
 
     let (_requiredFields, missingRequiredFields, initialValues) = getSuperpositionFinalFields(

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -135,11 +135,6 @@ let useSdkConfigHook = () => {
   let apiLogWrapper = LoggerHook.useApiLogWrapper()
   let baseUrl = GlobalHooks.useGetBaseUrl()()
   () => {
-    let platform = switch WebKit.platform {
-    | #ios | #iosWebView => "ios"
-    | #android | #androidWebView => "android"
-    | #web | #next => "web"
-    }
     let clientSecret = switch nativeProp.paymentSessionConfig.sdkAuthorization {
     | Some(auth) =>
       Utils.getSdkAuthorizationData(auth).clientSecret->Option.getOr(
@@ -147,7 +142,7 @@ let useSdkConfigHook = () => {
       )
     | None => nativeProp.paymentSessionConfig.clientSecret
     }
-    let uri = `${baseUrl}/v1/sdk/configs/${platform}/sdk_config.json?client_secret=${clientSecret}`
+    let uri = `${baseUrl}/v1/sdk/configs/${WebKit.platformGroup}/sdk_config.json?client_secret=${clientSecret}`
 
     APIUtils.fetchApiWrapper(
       ~uri,

--- a/src/hooks/WebKit.res
+++ b/src/hooks/WebKit.res
@@ -14,6 +14,12 @@ let (platform, platformString) = if Next.getNextEnv == "next" {
   (#web, "web")
 }
 
+let platformGroup = switch platform {
+| #ios | #iosWebView => "ios"
+| #android | #androidWebView => "android"
+| #web | #next => "web"
+}
+
 type useWebKit = {
   exitPaymentSheet: string => unit,
   sdkInitialised: string => unit,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [X] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## Description

- Added `organization_id`, `profile_id`, `processor_merchant_id `, `platform` as dimension for superposition's dynamicFields resolution.
- `organization_id`, `profile_id`, `processor_merchant_id` are received in `sdk-configs` api response.
- corresponding shared-code PR: https://github.com/juspay/hyperswitch-sdk-utils/pull/77
- Also, updated the renamed config parameters: `always_collect_billing_details_from_wallet_connector` and `always_collect_shipping_details_from_wallet_connector`.

## Screenshots / Recordings


<!-- Screenshots / Recordings of the change if applicable -->

<img width="1692" height="605" alt="image" src="https://github.com/user-attachments/assets/c081a241-a7bf-4a3e-9244-bd994a2c7cd5" />

---

## Affected Area & Impact

<!-- Select all that apply -->

- [X] Client Core
- [X] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**
- https://github.com/juspay/hyperswitch-sdk-utils/pull/77


## Testing

- [X] JS bundle built
- [ ] Tested in Android app
- [ ] Tested in iOS app
- [X] Tested in web app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app