### PR TITLE
fix: Field-Label and validation handling from superposition

### DIFF
--- a/src/components/dynamic/ButtonElement.res
+++ b/src/components/dynamic/ButtonElement.res
@@ -84,7 +84,7 @@ let make = (
   //       country,
   //     }
 
-  //     let (_requiredFields, missingRequiredFields, _fieldsToRender, _) = getSuperpositionFinalFields(
+  //     let (_requiredFields, _fieldsToRender, _) = getSuperpositionFinalFields(
   //       eligibleConnectors,
   //       configParams,
   //       requiredFieldsFromSource,

--- a/src/components/dynamic/ButtonElement.res
+++ b/src/components/dynamic/ButtonElement.res
@@ -84,7 +84,7 @@ let make = (
   //       country,
   //     }
 
-  //     let (_requiredFields, missingRequiredFields, _) = getSuperpositionFinalFields(
+  //     let (_requiredFields, missingRequiredFields, _fieldsToRender, _) = getSuperpositionFinalFields(
   //       eligibleConnectors,
   //       configParams,
   //       requiredFieldsFromSource,

--- a/src/components/dynamic/CryptoElement.res
+++ b/src/components/dynamic/CryptoElement.res
@@ -43,12 +43,20 @@ let make = (
   | (Some(currencyConfig), Some(networkConfig)) =>
     let {input: currencyInput, meta: currencyMeta} = ReactFinalForm.useField(
       currencyConfig.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.Required(None))},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(currencyConfig, ~fallback=Validation.Required(None)),
+        ),
+      },
     )
 
     let {input: networkInput, meta: networkMeta} = ReactFinalForm.useField(
       networkConfig.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.Required(None))},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(networkConfig, ~fallback=Validation.Required(None)),
+        ),
+      },
     )
 
     React.useEffect1(() => {

--- a/src/components/dynamic/DateElement.res
+++ b/src/components/dynamic/DateElement.res
@@ -160,7 +160,12 @@ let make = (
     <React.Fragment key={field.confirmRequestWritePath}>
       <View style={s({marginBottom: gap->dp})}>
         <ReactFinalForm.Field
-          name=field.confirmRequestWritePath validate=Some(createFieldValidator(validationRule))>
+          name=field.confirmRequestWritePath
+          validate=Some(
+            createFieldValidator(
+              FieldValidationResolver.resolveRule(field, ~fallback=validationRule),
+            ),
+          )>
           {fieldProps => <DatePicker fieldProps placeholder accessible />}
         </ReactFinalForm.Field>
       </View>

--- a/src/components/dynamic/FieldLabelResolver.res
+++ b/src/components/dynamic/FieldLabelResolver.res
@@ -10,3 +10,13 @@ let resolvePlaceholder = (
     | None => field.defaultLabelText
     }
   }
+
+let resolveLabel = (field: SuperpositionTypes.fieldConfig, getLocalized: string => option<string>) =>
+  switch field.merchantProvidedDisplayName {
+  | Some(text) if text !== "" => text
+  | _ =>
+    switch field.labelLocalizationKey {
+    | Some(key) => getLocalized(key)->Option.getOr(field.defaultLabelText)
+    | None => field.defaultLabelText
+    }
+  }

--- a/src/components/dynamic/FieldValidationResolver.res
+++ b/src/components/dynamic/FieldValidationResolver.res
@@ -1,0 +1,35 @@
+open Validation
+
+let ruleFromType = (ruleType: string): option<validationRule> =>
+  switch ruleType {
+  | "email" => Some(Email)
+  | "phone" => Some(Phone)
+  | "first_name" => Some(FirstName)
+  | "last_name" => Some(LastName)
+  | "date_of_birth" => Some(DateOfBirth)
+  | "iban" => Some(IBAN)
+  | "routing_number" => Some(RoutingNumber)
+  | "bank_account_number" => Some(BankAccountNumber)
+  | "blik_code" => Some(BlikCode)
+  | "pix_key" => Some(PixKey)
+  | "pix_cpf" => Some(PixCPF)
+  | "pix_cnpj" => Some(PixCNPJ)
+  | "gift_card_number" => Some(GiftCardNumber)
+  | "gift_card_pin" => Some(GiftCardPin)
+  | "nickname" => Some(Nickname)
+  | "card_number" => Some(CardNumber)
+  | _ => None
+  }
+
+let resolveRule = (
+  field: SuperpositionTypes.fieldConfig,
+  ~fallback: validationRule,
+): validationRule =>
+  switch field.validationRegexPattern {
+  | Some(pattern) if pattern->String.trim !== "" => Generic(pattern)
+  | _ =>
+    switch field.validationRuleType {
+    | Some(ruleType) => ruleFromType(ruleType)->Option.getOr(fallback)
+    | None => fallback
+    }
+  }

--- a/src/components/dynamic/FullNameElement.res
+++ b/src/components/dynamic/FullNameElement.res
@@ -13,11 +13,19 @@ module CombinedNameInput = {
     let {component, dangerColor, gap} = ThemebasedStyle.useThemeBasedStyle()
     let {input: firstNameInput, meta: firstNameMeta} = ReactFinalForm.useField(
       firstNameConfig.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.FirstName)},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(firstNameConfig, ~fallback=Validation.FirstName),
+        ),
+      },
     )
     let {input: lastNameInput, meta: lastNameMeta} = ReactFinalForm.useField(
       lastNameConfig.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.LastName)},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(lastNameConfig, ~fallback=Validation.LastName),
+        ),
+      },
     )
     let (inputValue, setInputValue) = React.useState(() => "")
     React.useEffect2(() => {
@@ -89,7 +97,11 @@ module SingleNameInput = {
     }
     let {input, meta} = ReactFinalForm.useField(
       config.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(validationRule)},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(config, ~fallback=validationRule),
+        ),
+      },
     )
     <View style={s({marginBottom: gap->dp})}>
       <CustomInput

--- a/src/components/dynamic/GenericTabElement.res
+++ b/src/components/dynamic/GenericTabElement.res
@@ -70,6 +70,7 @@ let make = (
     }
 
     let placeholder = FieldLabelResolver.resolvePlaceholder(field, getLocalized)
+    let label = FieldLabelResolver.resolveLabel(field, getLocalized)
 
     switch field.fieldRenderType {
     | Country =>
@@ -156,6 +157,7 @@ let make = (
           state={input.value->Option.getOr("")}
           setState=handleInputChange
           placeholder
+          animateLabel=label
           enableCrossIcon=false
           isValid={meta.error->Option.isNone || !meta.touched || meta.active}
           onFocus={_ => input.onFocus()}
@@ -180,7 +182,11 @@ let make = (
       <View style={s({marginBottom: gap->dp})}>
         <ReactFinalForm.Field
           name=field.confirmRequestWritePath
-          validate=Some(createFieldValidator(getValidationRuleForField(field)))>
+          validate=Some(
+            createFieldValidator(
+              FieldValidationResolver.resolveRule(field, ~fallback=getValidationRuleForField(field)),
+            ),
+          )>
           {fieldProps => renderFieldInput(field, fieldProps)}
         </ReactFinalForm.Field>
       </View>

--- a/src/components/dynamic/MergedElement.res
+++ b/src/components/dynamic/MergedElement.res
@@ -22,7 +22,11 @@ let make = (
   let fieldData = emailFields->Array.map(fieldConfig => {
     let {input, meta} = ReactFinalForm.useField(
       fieldConfig.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.Email)},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(fieldConfig, ~fallback=Validation.Email),
+        ),
+      },
     )
     (input, meta)
   })

--- a/src/components/dynamic/PhoneElement.res
+++ b/src/components/dynamic/PhoneElement.res
@@ -12,7 +12,11 @@ module SinglePhoneInput = {
     let {component, dangerColor, gap} = ThemebasedStyle.useThemeBasedStyle()
     let {input, meta} = ReactFinalForm.useField(
       config.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.Phone)},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(config, ~fallback=Validation.Phone),
+        ),
+      },
     )
     <View style={s({marginBottom: gap->dp})}>
       <CustomInput
@@ -62,12 +66,20 @@ let make = (
   | (Some(phoneCodeConfig), Some(phoneNumberConfig)) =>
     let {input: phoneCodeInput, meta: phoneCodeMeta} = ReactFinalForm.useField(
       phoneCodeConfig.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.Required(None))},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(phoneCodeConfig, ~fallback=Validation.Required(None)),
+        ),
+      },
     )
 
     let {input: phoneNumberInput, meta: phoneNumberMeta} = ReactFinalForm.useField(
       phoneNumberConfig.confirmRequestWritePath,
-      ~config={validate: createFieldValidator(Validation.Phone)},
+      ~config={
+        validate: createFieldValidator(
+          FieldValidationResolver.resolveRule(phoneNumberConfig, ~fallback=Validation.Phone),
+        ),
+      },
     )
 
     React.useEffect1(() => {

--- a/src/contexts/DynamicFieldsContext.res
+++ b/src/contexts/DynamicFieldsContext.res
@@ -202,7 +202,7 @@ let make = (~children) => {
     | _ => ()
     }
 
-    let (_requiredFields, _missingRequiredFields, fieldsToRender, initialValues) = getSuperpositionFinalFields(
+    let (_requiredFields, fieldsToRender, initialValues) = getSuperpositionFinalFields(
       eligibleConnectors,
       configParams,
       buildIntentData(requiredFieldsFromPML),
@@ -370,13 +370,13 @@ let make = (~children) => {
       organization_id: ?organization_id,
     }
 
-    let (_requiredFields, missingRequiredFields, fieldsToRender, initialValues) = getSuperpositionFinalFields(
+    let (_requiredFields, fieldsToRender, initialValues) = getSuperpositionFinalFields(
       eligibleConnectors,
       configParams,
       buildIntentData(requiredFieldsFromSource),
     )
 
-    let isFieldsMissing = missingRequiredFields->Array.length > 0
+    let isFieldsMissing = fieldsToRender->Array.length > 0
 
     if isFieldsMissing {
       setWalletData(

--- a/src/contexts/DynamicFieldsContext.res
+++ b/src/contexts/DynamicFieldsContext.res
@@ -202,20 +202,10 @@ let make = (~children) => {
     | _ => ()
     }
 
-    let (_requiredFields, missingRequiredFields, initialValues) = getSuperpositionFinalFields(
+    let (_requiredFields, _missingRequiredFields, fieldsToRender, initialValues) = getSuperpositionFinalFields(
       eligibleConnectors,
       configParams,
       buildIntentData(requiredFieldsFromPML),
-    )
-
-    let fieldsToRender = _requiredFields->Array.filter(field =>
-      switch field.renderWhenPrefilled {
-      | Some(true) => true
-      | _ =>
-        missingRequiredFields->Array.some(missingField =>
-          missingField.confirmRequestWritePath === field.confirmRequestWritePath
-        )
-      }
     )
 
     fieldsToRender->Array.forEach(field => {
@@ -380,20 +370,10 @@ let make = (~children) => {
       organization_id: ?organization_id,
     }
 
-    let (_requiredFields, missingRequiredFields, initialValues) = getSuperpositionFinalFields(
+    let (_requiredFields, missingRequiredFields, fieldsToRender, initialValues) = getSuperpositionFinalFields(
       eligibleConnectors,
       configParams,
       buildIntentData(requiredFieldsFromSource),
-    )
-
-    let fieldsToRender = _requiredFields->Array.filter(field =>
-      switch field.renderWhenPrefilled {
-      | Some(true) => true
-      | _ =>
-        missingRequiredFields->Array.some(missingField =>
-          missingField.confirmRequestWritePath === field.confirmRequestWritePath
-        )
-      }
     )
 
     let isFieldsMissing = missingRequiredFields->Array.length > 0

--- a/src/contexts/DynamicFieldsContext.res
+++ b/src/contexts/DynamicFieldsContext.res
@@ -208,7 +208,17 @@ let make = (~children) => {
       buildIntentData(requiredFieldsFromPML),
     )
 
-    missingRequiredFields->Array.forEach(field => {
+    let fieldsToRender = _requiredFields->Array.filter(field =>
+      switch field.renderWhenPrefilled {
+      | Some(true) => true
+      | _ =>
+        missingRequiredFields->Array.some(missingField =>
+          missingField.confirmRequestWritePath === field.confirmRequestWritePath
+        )
+      }
+    )
+
+    fieldsToRender->Array.forEach(field => {
       let isCountryDropdown = field.fieldRenderType === Country
       if isCountryDropdown {
         let currentCountry =
@@ -230,7 +240,7 @@ let make = (~children) => {
     })
 
     (
-      missingRequiredFields,
+      fieldsToRender,
       CommonUtils.mergeDict(
         switch formDataRef {
         | Some(ref) => CommonUtils.mergeDict(initialValues, ref.current)
@@ -376,11 +386,21 @@ let make = (~children) => {
       buildIntentData(requiredFieldsFromSource),
     )
 
+    let fieldsToRender = _requiredFields->Array.filter(field =>
+      switch field.renderWhenPrefilled {
+      | Some(true) => true
+      | _ =>
+        missingRequiredFields->Array.some(missingField =>
+          missingField.confirmRequestWritePath === field.confirmRequestWritePath
+        )
+      }
+    )
+
     let isFieldsMissing = missingRequiredFields->Array.length > 0
 
     if isFieldsMissing {
       setWalletData(
-        ~missingRequiredFields,
+        ~missingRequiredFields=fieldsToRender,
         ~initialValues=switch formData {
         | Some(data) =>
           Utils.pruneUnusedFieldsFromDict(

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -304,7 +304,7 @@ let make = (
   //         country,
   //       }
 
-  //       let (_requiredFields, missingRequiredFields, _) = getSuperpositionFinalFields(
+  //       let (_requiredFields, missingRequiredFields, _fieldsToRender, _) = getSuperpositionFinalFields(
   //         eligibleConnectors,
   //         configParams,
   //         requiredFieldsFromSource,

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -304,7 +304,7 @@ let make = (
   //         country,
   //       }
 
-  //       let (_requiredFields, missingRequiredFields, _fieldsToRender, _) = getSuperpositionFinalFields(
+  //       let (_requiredFields, _fieldsToRender, _) = getSuperpositionFinalFields(
   //         eligibleConnectors,
   //         configParams,
   //         requiredFieldsFromSource,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## What & Why

Wire up previously-unused Superposition fieldConfig keys in the dynamic fields.

Three field-config capabilities that were parsed but never consumed are now honored in client-core (no shared-code changes):

- Config-driven validation — new FieldValidationResolver.resolveRule maps each field's validation_rule_type / validation_regex_pattern to a Validation rule, with a 3-tier fallback (regex → semantic type → the component's existing hardcoded rule). Wired into the email, phone, name, crypto, date and generic-tab validators. Card validation is left as-is. Fully backward-compatible: fields with no validation keys behave exactly as before.
- renderWhenPrefilled — in DynamicFieldsContext, a prefilled field is now shown (pre-populated) instead of hidden when config sets render_when_prefilled: true; default keeps today's hide-when-prefilled behavior. The wallet sheet still opens only for genuinely missing fields.
- Localized labels — new FieldLabelResolver.resolveLabel drives the floating label from merchant_provided_display_name (highest priority) → label_localization_key → default_label_text, wired into the generic-tab text inputs.

Dormant against current config (all live fields have render_when_prefilled: false and no validation keys except the email/DOB fields), so no behavior change today — it just enables the capabilities for when config opts in.


---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [x] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
