### PR TITLE
fix: avoid sending empty billing address line1 for Apple Pay when street is absent

### DIFF
--- a/src/utility/logics/AddressUtils.res
+++ b/src/utility/logics/AddressUtils.res
@@ -80,7 +80,10 @@ let getApplePayBillingAddress = (dict, str, shipping: option<string>) => {
       getOptionString(postalAddress, "isoCountryCode")->Option.map(country =>
         country->String.toUpperCase
       )
-    let street = getString(postalAddress, "street", "")->String.split("\n")
+    let street =
+      getOptionString(postalAddress, "street")
+      ->Option.mapOr([], street => street->String.split("\n"))
+      ->Array.filter(line => line->String.trim !== "")
     let line1 = Array.at(street, 0)
     let line2 = if Array.length(street) > 1 {
       Array.at(street, 1)


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---

## Description

When paying via Apple Pay, we parse the billing details returned by the Apple Pay
SDK in `getApplePayBillingAddress` and forward them to the Hyperswitch backend.

If Apple Pay / the backend does not return a `street`, the parsing produced an
empty-string `line1` while every other address field was correctly `null`.

### Root cause

```rescript
let street = getString(postalAddress, "street", "")->String.split("\n")
let line1 = Array.at(street, 0)

getString(..., "street", "") falls back to "" when there is no street.
""->String.split("\n") returns [""] — an array containing a single empty
string, not an empty array — so Array.at([""], 0) resolves to Some("").

All the other address fields use ?getOptionString(...), which correctly yields
None (and is omitted) when absent, so only line1 leaked through as "".
```


## Fix

```rescript
let street =
  getOptionString(postalAddress, "street")
  ->Option.mapOr([], street => street->String.split("\n"))
  ->Array.filter(line => line->String.trim !== "")
let line1 = Array.at(street, 0)
```

- `getOptionString` returns `None` when the key is absent, so we never split a placeholder.
- If present, we split as before and drop any blank/whitespace-only fragments.
- An empty/absent street now yields `[]`, so `line1`, `line2`, and `line3` all resolve to `None` and are omitted — no more stray empty strings.

This also hardens the non-empty case: values like `"123 Main St\n\n"` no longer produce an empty `line2`, while normal multi-line streets are unaffected.

## How did you test this?

- `yarn re:build` passes.
- Verified parsing behavior:
  - No street → `line1` / `line2` / `line3` all `None` (omitted).
  - `"123 Main St\nApt 4"` → `line1 = "123 Main St"`, `line2 = "Apt 4"` (unchanged).
  - `"123 Main St\n\n"` → `line1 = "123 Main St"`, no empty `line2`.

## Checklist

- [x] I formatted / built the code (`yarn re:build`)
- [x] Change is scoped to `src/utility/logics/AddressUtils.res`


## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [ ] Android 
- [ ] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [x] Tested in Android app
- [ ] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
