### PR TITLE
Refactor client API context to remove per-component optional handling

### DIFF
--- a/src/components/common/CustomAccordionView.res
+++ b/src/components/common/CustomAccordionView.res
@@ -132,9 +132,7 @@ let make = (
   ~onAllCollapsed: bool => unit=_ => (),
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData} = AllApiDataContextNew.useData()
   let layout = nativeProp.configuration.paymentMethodLayout
 
   let defaultCollapsed = layout.defaultCollapsed
@@ -143,13 +141,10 @@ let make = (
 
   let (expandedSections, setExpandedSections) = React.useState(_ => [])
   let (showMore, setShowMore) = React.useState(_ => true)
-  
-  let hasData = switch clientData {
-  | Some(data) =>
-    data.payment_methods_enabled->Array.length > 0 ||
-    data.customer_payment_methods->Array.length > 0
-  | None => false
-  }
+
+  let hasData =
+    clientData.payment_methods_enabled->Array.length > 0 ||
+    clientData.customer_payment_methods->Array.length > 0
 
   React.useEffect2(() => {
     if hasData && expandedSections->Array.length === 0 {
@@ -166,9 +161,7 @@ let make = (
         ...GlobalConfirmButton.defaultConfirmButtonData,
         loading: false,
         visible: !(expandIndex->Array.length === 0) ||
-        (clientData
-        ->Option.map(c => c.customer_payment_methods->Array.length > 0)
-        ->Option.getOr(false) &&
+        (clientData.customer_payment_methods->Array.length > 0 &&
           layout.savedMethodCustomization.groupingBehavior.displayInSeparateSection),
       })
       setExpandedSections(_ => expandIndex)

--- a/src/components/dynamic/DynamicComponent.res
+++ b/src/components/dynamic/DynamicComponent.res
@@ -1,9 +1,7 @@
 @react.component
 let make = (~setConfirmButtonData) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData} = AllApiDataContextNew.useData()
   let (viewPortContants, _) = React.useContext(ViewportContext.viewPortContext)
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
 
@@ -155,21 +153,13 @@ let make = (~setConfirmButtonData) => {
       ~payment_method_data=?CommonUtils.mergeDict(paymentMethodDataDict, tabDict)->Dict.get(
         "payment_method_data",
       ),
-      ~payment_type=clientData
-      ->Option.map(data => data.intent_data.payment_type)
-      ->Option.getOr(NORMAL),
-      ~payment_type_str=?clientData
-      ->Option.map(data => data.intent_data.payment_type_str)
-      ->Option.getOr(None),
-      ~appURL=?{
-        clientData->Option.map(data => data.intent_data.return_url)
-      },
+      ~payment_type=clientData.intent_data.payment_type,
+      ~payment_type_str=?clientData.intent_data.payment_type_str,
+      ~appURL=clientData.intent_data.return_url,
       ~isSaveCardCheckboxVisible={
         payment_method === CARD && nativeProp.configuration.displaySavedPaymentMethodsCheckbox
       },
-      ~isGuestCustomer=clientData
-      ->Option.map(data => data.intent_data.is_guest_customer)
-      ->Option.getOr(true),
+      ~isGuestCustomer=clientData.intent_data.is_guest_customer,
       ~isNicknameSelected,
       ~email?,
       ~screen_height=viewPortContants.screenHeight,

--- a/src/components/dynamic/DynamicFields.res
+++ b/src/components/dynamic/DynamicFields.res
@@ -14,9 +14,7 @@ let make = (
   ~checkEligibility: option<string> => unit=_ => (),
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData} = AllApiDataContextNew.useData()
   let {
     isNicknameSelected,
     setIsNicknameSelected,
@@ -55,10 +53,8 @@ let make = (
       {switch (
         nativeProp.configuration.displaySavedPaymentMethodsCheckbox,
         nativeProp.configuration.alwaysSendCustomerAcceptance,
-        clientData->Option.map(data => data.intent_data.is_guest_customer)->Option.getOr(true),
-        clientData
-        ->Option.map(data => data.intent_data.payment_type)
-        ->Option.getOr(NORMAL),
+        clientData.intent_data.is_guest_customer,
+        clientData.intent_data.payment_type,
       ) {
       | (true, false, false, NEW_MANDATE | NORMAL) =>
         <ReactNative.View
@@ -77,12 +73,10 @@ let make = (
       | _ => React.null
       }}
       {switch (
-        clientData->Option.map(data => data.intent_data.is_guest_customer)->Option.getOr(true),
+        clientData.intent_data.is_guest_customer,
         isNicknameSelected,
         nativeProp.configuration.displaySavedPaymentMethodsCheckbox,
-        clientData
-        ->Option.map(data => data.intent_data.payment_type)
-        ->Option.getOr(NORMAL),
+        clientData.intent_data.payment_type,
       ) {
       | (false, _, true, NEW_MANDATE | NORMAL) =>
         isNicknameSelected

--- a/src/components/dynamic/DynamicFields.res
+++ b/src/components/dynamic/DynamicFields.res
@@ -14,9 +14,7 @@ let make = (
   ~checkEligibility: option<string> => unit=_ => (),
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData} = AllApiDataContextNew.useData()
   let {
     isNicknameSelected,
     setIsNicknameSelected,
@@ -55,10 +53,8 @@ let make = (
       {switch (
         nativeProp.configuration.displaySavedPaymentMethodsCheckbox,
         nativeProp.configuration.alwaysSendCustomerAcceptance,
-        clientData->Option.map(data => data.intent_data.is_guest_customer)->Option.getOr(true),
-        clientData
-        ->Option.map(data => data.intent_data.payment_type)
-        ->Option.getOr(NORMAL),
+        clientData.intent_data.is_guest_customer,
+        clientData.intent_data.payment_type,
       ) {
       | (true, false, false, NEW_MANDATE | NORMAL) =>
         <ReactNative.View
@@ -76,14 +72,12 @@ let make = (
         </ReactNative.View>
       | _ => React.null
       }}
-      <UIUtils.RenderIf condition={!nativeProp.configuration.hideCardNicknameField}>
+       <UIUtils.RenderIf condition={!nativeProp.configuration.hideCardNicknameField}>
         {switch (
-          clientData->Option.map(data => data.intent_data.is_guest_customer)->Option.getOr(true),
+          clientData.intent_data.is_guest_customer,
           isNicknameSelected,
           nativeProp.configuration.displaySavedPaymentMethodsCheckbox,
-          clientData
-          ->Option.map(data => data.intent_data.payment_type)
-          ->Option.getOr(NORMAL),
+          clientData.intent_data.payment_type,
         ) {
         | (false, _, true, NEW_MANDATE | NORMAL) =>
           isNicknameSelected

--- a/src/components/elements/ConfirmButton.res
+++ b/src/components/elements/ConfirmButton.res
@@ -8,7 +8,7 @@ let make = (
   ~errorText=None,
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let allApiData = AllApiDataContextNew.useOptionalData()
   let localeObject = GetLocale.useGetLocalObj()
 
   <>
@@ -20,14 +20,13 @@ let make = (
           paymentMethod
           ?paymentExperience
           ?customerPaymentExperience
-          displayText={switch nativeProp.configuration.primaryButtonLabel {
-          | Some(str) => str
-          | None =>
-            clientData
-            ->Option.map(data => data.intent_data.payment_type)
-            ->Option.getOr(NORMAL) !== NORMAL
+          displayText={switch (nativeProp.configuration.primaryButtonLabel, allApiData) {
+          | (Some(str), _) => str
+          | (None, Some({clientData})) =>
+            clientData.intent_data.payment_type !== NORMAL
               ? "Pay Now"
               : localeObject.payNowButton
+          | (None, None) => localeObject.payNowButton
           }}
         />}
     <HyperSwitchBranding />

--- a/src/contexts/AllApiDataContextNew.res
+++ b/src/contexts/AllApiDataContextNew.res
@@ -1,13 +1,27 @@
-let allApiDataContext = React.createContext((
-  (None: option<ClientResponseType.clientResponse>),
-  (None: option<array<SessionsType.sessions>>),
-  (None: option<SdkConfigTypes.sdkConfigValue>),
-))
+type contextValue = {
+  clientData: ClientResponseType.clientResponse,
+  sdkConfigData: SdkConfigTypes.sdkConfigValue,
+  sessionTokenData: option<array<SessionsType.sessions>>,
+}
+
+let allApiDataContext: React.Context.t<option<contextValue>> = React.createContext(None)
 
 module Provider = {
   let make = React.Context.provider(allApiDataContext)
 }
+
 @react.component
-let make = (~children, ~clientData, ~sessionTokenData, ~sdkConfigData) => {
-  <Provider value=(clientData, sessionTokenData, sdkConfigData)> children </Provider>
+let make = (~children, ~allApiData: option<contextValue>) => {
+  <Provider value=allApiData> children </Provider>
 }
+
+let useOptionalData = () => React.useContext(allApiDataContext)
+
+let useData = () =>
+  switch React.useContext(allApiDataContext) {
+  | Some(data) => data
+  | None =>
+    Exn.raiseError(
+      "AllApiDataContextNew.useData called while API data is still loading — render this component below a loading gate.",
+    )
+  }

--- a/src/contexts/DynamicFieldsContext.res
+++ b/src/contexts/DynamicFieldsContext.res
@@ -151,10 +151,19 @@ let applyCountryDefaults = (
 let make = (~children) => {
   let formDataRef = Some(React.useRef(Dict.make()))
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, sdkConfigData) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
-  let superpositionConfig = sdkConfigData->Option.getOr(SdkConfigTypes.defaultSdkConfigValue)
+  let allApiData = AllApiDataContextNew.useOptionalData()
+  let superpositionConfig = switch allApiData {
+  | Some({sdkConfigData}) => sdkConfigData
+  | None => SdkConfigTypes.defaultSdkConfigValue
+  }
+  let requireClientData = () =>
+    switch allApiData {
+    | Some({clientData}) => clientData
+    | None =>
+      Exn.raiseError(
+        "DynamicFieldsContext: field builders were called before API data arrived — call them only from components below a loading gate.",
+      )
+    }
   let profile = superpositionConfig.account_config->Option.flatMap(ac => ac.profile)
   let collectBillingDetailsFromWalletConnector = SdkConfigParser.getCollectBillingDetailsFromWalletConnector(
     profile,
@@ -193,6 +202,7 @@ let make = (~children) => {
     formData,
     isScreenFocus,
   ) => {
+    let clientData = requireClientData()
     let eligibleConnectors =
       SdkConfigParser.getEligibleConnectorsFromPaymentMethods(
         superpositionConfig.payment_methods,
@@ -200,22 +210,15 @@ let make = (~children) => {
         paymentMethodData.payment_method_type,
       )->Array.map(JSON.Encode.string)
 
-    let rawIntentData =
-      clientData
-      ->Option.map(data => data.intent_data.raw_intent_data)
-      ->Option.getOr(Dict.make()->JSON.Encode.object)
-
     let (intentData, defaultCountry) = prepareIntentData(
-      rawIntentData,
+      clientData.intent_data.raw_intent_data,
       nativeProp.sdkParams.country,
     )
 
     let configParams: SuperpositionTypes.superpositionBaseContext = {
       payment_method: paymentMethodData.payment_method_str,
       payment_method_type: paymentMethodData.payment_method_type,
-      mandate_type: clientData
-      ->Option.map(data => data.intent_data.payment_type === NORMAL ? "non_mandate" : "mandate")
-      ->Option.getOr("non_mandate"),
+      mandate_type: clientData.intent_data.payment_type === NORMAL ? "non_mandate" : "mandate",
       always_collect_billing_details_from_wallet_connector: collectBillingDetailsFromWalletConnector,
       always_collect_shipping_details_from_wallet_connector: collectShippingDetailsFromWalletConnector,
       country: switch country {
@@ -310,6 +313,7 @@ let make = (~children) => {
     useIntentData,
     formData,
   ) => {
+    let clientData = requireClientData()
     let eligibleConnectors =
       SdkConfigParser.getEligibleConnectorsFromPaymentMethods(
         superpositionConfig.payment_methods,
@@ -328,9 +332,7 @@ let make = (~children) => {
       | None => Dict.make()->JSON.Encode.object
       }
     } else {
-      clientData
-      ->Option.map(data => data.intent_data.raw_intent_data)
-      ->Option.getOr(Dict.make()->JSON.Encode.object)
+      clientData.intent_data.raw_intent_data
     }
 
     let (intentData, defaultCountry) = prepareIntentData(
@@ -341,11 +343,7 @@ let make = (~children) => {
     let configParams: SuperpositionTypes.superpositionBaseContext = {
       payment_method: paymentMethodData.payment_method_str,
       payment_method_type: paymentMethodData.payment_method_type,
-      mandate_type: clientData
-      ->Option.map(data => data.intent_data.payment_type)
-      ->Option.getOr(NORMAL) === NORMAL
-        ? "non_mandate"
-        : "mandate",
+      mandate_type: clientData.intent_data.payment_type === NORMAL ? "non_mandate" : "mandate",
       always_collect_billing_details_from_wallet_connector: collectBillingDetailsFromWalletConnector,
       always_collect_shipping_details_from_wallet_connector: collectShippingDetailsFromWalletConnector,
       country: switch country {

--- a/src/hooks/AllApiDataModifier.res
+++ b/src/hooks/AllApiDataModifier.res
@@ -16,13 +16,10 @@ type walletProp = {
 
 let usePaymentMethodModifier = () => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, sessionTokenData, sdkConfigData) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
-  let superpositionConfig = sdkConfigData->Option.getOr(SdkConfigTypes.defaultSdkConfigValue)
+  let {clientData, sessionTokenData} = AllApiDataContextNew.useData()
   let samsungPayStatus = SamsungPay.useSamsungPayValidityHook()
 
-  React.useMemo3(() => {
+  React.useMemo2(() => {
     let groupingBehavior = nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.groupingBehavior
 
     // Show a merged "Saved" tab only when displaySavedPaymentMethods=true AND displayInSeparateScreen=false AND groupByPaymentMethods=false
@@ -33,71 +30,37 @@ let usePaymentMethodModifier = () => {
       !groupingBehavior.displayInSeparateSection
 
     let (initialTabArr, initialElementArr) = if showMergedSavedTab {
-      switch clientData {
-      | None =>
-        switch nativeProp.sdkState {
-        | PaymentSheet | WidgetPaymentSheet | HostedCheckout | TabSheet | WidgetTabSheet => (
-            [
-              {
-                name: "Saved",
-                paymentMethodType: "saved_payment_method",
-                componentHoc: (~isScreenFocus as _, ~setConfirmButtonData as _) =>
-                  <InitialLoader />,
-              },
-            ],
-            [],
-          )
-        | _ => ([], [])
-        }
-      | Some(customerPaymentMethods) =>
-        switch nativeProp.sdkState {
-        | PaymentSheet | WidgetPaymentSheet | HostedCheckout | TabSheet | WidgetTabSheet =>
-          let customerPaymentMethods = customerPaymentMethods.customer_payment_methods
-          // ->Array.filter(
-          //   customer_payment_method_type =>
-          //     customer_payment_method_type.payment_method !== WALLET,
-          // )
-          (
-            customerPaymentMethods->Array.length > 0
-              ? [
-                  {
-                    name: "Saved",
-                    paymentMethodType: "saved_payment_method",
-                    componentHoc: (~isScreenFocus, ~setConfirmButtonData) =>
-                      <SavedPaymentSheet
-                        isScreenFocus
-                        customerPaymentMethods
-                        setConfirmButtonData
-                        merchantName={clientData
-                        ->Option.map(data => data.intent_data.merchant_name)
-                        ->Option.getOr(nativeProp.configuration.merchantDisplayName)}
-                        animated=true
-                        style={ReactNative.Style.s({marginBottom: 10.->ReactNative.Style.dp})}
-                      />,
-                  },
-                ]
-              : [],
-            [],
-          )
-        | ButtonSheet | WidgetButtonSheet => // elementArr->Array.push(
-          //   <PaymentMethod
-          //     key={paymentMethodData.payment_method_type}
-          //     paymentMethodData
-          //     sessionObject
-          //     methodType=ELEMENT
-          //   />,
-          // )
-          ([], [])
-        | _ => ([], [])
-        }
+      switch nativeProp.sdkState {
+      | PaymentSheet | WidgetPaymentSheet | HostedCheckout | TabSheet | WidgetTabSheet =>
+        let customerPaymentMethods = clientData.customer_payment_methods
+        (
+          customerPaymentMethods->Array.length > 0
+            ? [
+                {
+                  name: "Saved",
+                  paymentMethodType: "saved_payment_method",
+                  componentHoc: (~isScreenFocus, ~setConfirmButtonData) =>
+                    <SavedPaymentSheet
+                      isScreenFocus
+                      customerPaymentMethods
+                      setConfirmButtonData
+                      merchantName=clientData.intent_data.merchant_name
+                      animated=true
+                      style={ReactNative.Style.s({marginBottom: 10.->ReactNative.Style.dp})}
+                    />,
+                },
+              ]
+            : [],
+          [],
+        )
+      | ButtonSheet | WidgetButtonSheet => ([], [])
+      | _ => ([], [])
       }
     } else {
       ([], [])
     }
 
-    switch clientData {
-    | Some(clientData) =>
-      clientData.payment_methods_enabled->Array.reduce(
+    clientData.payment_methods_enabled->Array.reduce(
         (initialTabArr, initialElementArr, []),
         (
           (tabArr, elementArr, giftCardArr): (
@@ -222,55 +185,11 @@ let usePaymentMethodModifier = () => {
           (tabArr, elementArr, giftCardArr)
         },
       )
-    | None =>
-      let loadingTabElement = {
-        name: "loading",
-        paymentMethodType: "loading",
-        componentHoc: (~isScreenFocus as _, ~setConfirmButtonData as _) => <>
-          <Space height=10. />
-          <CustomLoader />
-          <Space height=10. />
-          <CustomLoader />
-          <Space height=20. />
-        </>,
-      }
-
-      switch nativeProp.sdkState {
-      | PaymentSheet | WidgetPaymentSheet => (
-          [loadingTabElement, loadingTabElement, loadingTabElement, loadingTabElement],
-          [<CustomLoader key="1" />, <Space key="2" />],
-          [],
-        )
-      | TabSheet | WidgetTabSheet => (
-          [loadingTabElement, loadingTabElement, loadingTabElement, loadingTabElement],
-          [],
-          [],
-        )
-      | ButtonSheet | WidgetButtonSheet => (
-          [],
-          [
-            <CustomLoader key="1" />,
-            <Space key="2" />,
-            <CustomLoader key="3" />,
-            <Space key="4" />,
-            <CustomLoader key="5" />,
-            <Space key="6" />,
-            <CustomLoader key="7" />,
-            <Space key="8" />,
-            <CustomLoader key="9" />,
-          ],
-          [],
-        )
-      | _ => ([], [], [])
-      }
-    }
-  }, (clientData, sessionTokenData, superpositionConfig.payment_methods))
+  }, (clientData, sessionTokenData))
 }
 
 let useAddWebPaymentButton = () => {
-  let (clientData, sessionTokenData, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData, sessionTokenData} = AllApiDataContextNew.useData()
   let (addApplePay, addGooglePay) =
     ReactNative.Platform.os === #web
       ? WebButtonHook.usePayButton()
@@ -278,9 +197,7 @@ let useAddWebPaymentButton = () => {
 
   React.useMemo2(() => {
     if ReactNative.Platform.os === #web {
-      switch clientData {
-      | Some(clientData) =>
-        clientData.payment_methods_enabled->Array.forEach(paymentMethodData => {
+      clientData.payment_methods_enabled->Array.forEach(paymentMethodData => {
           let sessionObject = switch sessionTokenData {
           | Some(sessionData) =>
             sessionData
@@ -328,8 +245,6 @@ let useAddWebPaymentButton = () => {
           | _ => ()
           }
         })
-      | None => ()
-      }
     }
   }, (clientData, sessionTokenData))
 }

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -159,7 +159,7 @@ let useSdkConfigHook = () => {
 
 let usePostSessionTokensHook = () => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let {clientData} = AllApiDataContextNew.useData()
   let baseUrl = GlobalHooks.useGetBaseUrl()()
   let apiLogWrapper = LoggerHook.useApiLogWrapper()
   (
@@ -167,10 +167,7 @@ let usePostSessionTokensHook = () => {
     ~sessionObject: SessionsType.sessions,
     (),
   ) => {
-    let payment_type_str =
-      clientData
-      ->Option.map(a => a.intent_data.payment_type_str)
-      ->Option.getOr(None)
+    let payment_type_str = clientData.intent_data.payment_type_str
 
     let body =
       PaymentUtils.generatePostSessionTokensBody(
@@ -199,7 +196,7 @@ let usePostSessionTokensHook = () => {
 
 let useBrowserHook = () => {
   let retrievePayment = useRetrieveHook()
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let allApiData = AllApiDataContextNew.useOptionalData()
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   let intervalId = React.useRef(Nullable.null)
   let redirectionSuccessHandler = BrowserRedirectionHooks.useBrowserRedirectionSuccessHook()
@@ -218,7 +215,7 @@ let useBrowserHook = () => {
       openUrl,
       Utils.getReturnUrl(
         ~appId=nativeProp.sdkParams.appId,
-        ~appURL=clientData->Option.map(data => data.intent_data.return_url),
+        ~appURL=allApiData->Option.map(data => data.clientData.intent_data.return_url),
       ),
       intervalId,
       ~useEphemeralWebSession,

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -146,7 +146,7 @@ let useSdkConfigHook = () => {
 
 let usePostSessionTokensHook = () => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let {clientData} = AllApiDataContextNew.useData()
   let baseUrl = GlobalHooks.useGetBaseUrl()()
   let apiLogWrapper = LoggerHook.useApiLogWrapper()
   (
@@ -154,10 +154,7 @@ let usePostSessionTokensHook = () => {
     ~sessionObject: SessionsType.sessions,
     (),
   ) => {
-    let payment_type_str =
-      clientData
-      ->Option.map(a => a.intent_data.payment_type_str)
-      ->Option.getOr(None)
+    let payment_type_str = clientData.intent_data.payment_type_str
 
     let body =
       PaymentUtils.generatePostSessionTokensBody(
@@ -186,7 +183,7 @@ let usePostSessionTokensHook = () => {
 
 let useBrowserHook = () => {
   let retrievePayment = useRetrieveHook()
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let allApiData = AllApiDataContextNew.useOptionalData()
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   let intervalId = React.useRef(Nullable.null)
   let redirectionSuccessHandler = BrowserRedirectionHooks.useBrowserRedirectionSuccessHook()
@@ -205,7 +202,7 @@ let useBrowserHook = () => {
       openUrl,
       Utils.getReturnUrl(
         ~appId=nativeProp.sdkParams.appId,
-        ~appURL=clientData->Option.map(data => data.intent_data.return_url),
+        ~appURL=allApiData->Option.map(data => data.clientData.intent_data.return_url),
       ),
       intervalId,
       ~useEphemeralWebSession,

--- a/src/pages/hostedCheckout/CheckoutView.res
+++ b/src/pages/hostedCheckout/CheckoutView.res
@@ -98,7 +98,8 @@ module CheckoutDetails = {
 
 @react.component
 let make = (~isDesktop) => {
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let clientData =
+    AllApiDataContextNew.useOptionalData()->Option.map(allApiData => allApiData.clientData)
   let {textSecondary} = ThemebasedStyle.useThemeBasedStyle()
 
   let (showDetails, setShowDetails) = React.useState(() => false)

--- a/src/pages/payment/PaymentMethod.res
+++ b/src/pages/payment/PaymentMethod.res
@@ -9,9 +9,7 @@ let make = (
   ~methodType=TAB,
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData} = AllApiDataContextNew.useData()
   let (viewPortContants, _) = React.useContext(ViewportContext.viewPortContext)
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
   let redirectHook = AllPaymentHooks.useRedirectHook()
@@ -27,9 +25,9 @@ let make = (
     | None => setEligibilityStatus(_ => Allowed)
     | Some(cardNumber) =>
       let shouldCheck =
-        clientData
-        ->Option.flatMap(d => d.sdk_next_action.next_action)
-        ->Option.mapOr(false, action => action == "eligibility_check")
+        clientData.sdk_next_action.next_action->Option.mapOr(false, action =>
+          action == "eligibility_check"
+        )
 
       if shouldCheck {
         setEligibilityStatus(_ => Pending)
@@ -194,22 +192,14 @@ let make = (
       ~payment_method_data=?CommonUtils.mergeDict(paymentMethodDataDict, tabDict)->Dict.get(
         "payment_method_data",
       ),
-      ~payment_type=clientData
-      ->Option.map(data => data.intent_data.payment_type)
-      ->Option.getOr(NORMAL),
-      ~payment_type_str=?clientData
-      ->Option.map(data => data.intent_data.payment_type_str)
-      ->Option.getOr(None),
-      ~appURL=?{
-        clientData->Option.map(data => data.intent_data.return_url)
-      },
+      ~payment_type=clientData.intent_data.payment_type,
+      ~payment_type_str=?clientData.intent_data.payment_type_str,
+      ~appURL=clientData.intent_data.return_url,
       ~isSaveCardCheckboxVisible={
         paymentMethodData.payment_method === CARD &&
           nativeProp.configuration.displaySavedPaymentMethodsCheckbox
       },
-      ~isGuestCustomer=clientData
-      ->Option.map(data => data.intent_data.is_guest_customer)
-      ->Option.getOr(true),
+      ~isGuestCustomer=clientData.intent_data.is_guest_customer,
       ~isNicknameSelected,
       ~email?,
       ~screen_height=viewPortContants.screenHeight,

--- a/src/pages/payment/PaymentSheet.res
+++ b/src/pages/payment/PaymentSheet.res
@@ -1,7 +1,7 @@
 @react.component
 let make = (~setConfirmButtonData, ~isLoading, ~tabArr, ~elementArr, ~giftCardArr) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let {clientData} = AllApiDataContextNew.useData()
   AllApiDataModifier.useAddWebPaymentButton()
 
   let (allAccordionCollapsed, setAllAccordionCollapsed) = React.useState(_ => false)
@@ -11,9 +11,7 @@ let make = (~setConfirmButtonData, ~isLoading, ~tabArr, ~elementArr, ~giftCardAr
       elementArr
       isLoading
       hideDivider={tabArr->Array.length === 0 && giftCardArr->Array.length === 0}
-      showDisclaimer={clientData
-      ->Option.map(data => data.intent_data.payment_type)
-      ->Option.getOr(NORMAL) !== NORMAL}
+      showDisclaimer={clientData.intent_data.payment_type !== NORMAL}
     />
     <GiftCardComponent isLoading giftCardArr />
     <SavedPaymentMethodSection

--- a/src/pages/payment/SavedCardToggleTab.res
+++ b/src/pages/payment/SavedCardToggleTab.res
@@ -6,7 +6,7 @@ let make = (
   ~savedCardMethods: ClientResponseType.customerPaymentMethods,
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(AllApiDataContextNew.allApiDataContext)
+  let {clientData} = AllApiDataContextNew.useData()
   let localeObject = GetLocale.useGetLocalObj()
 
   let hasSavedCards = savedCardMethods->Array.length > 0
@@ -16,10 +16,7 @@ let make = (
     setShowSavedView(_ => value)
   }, [setShowSavedView])
 
-  let merchantName =
-    clientData
-    ->Option.map(data => data.intent_data.merchant_name)
-    ->Option.getOr(nativeProp.configuration.merchantDisplayName)
+  let merchantName = clientData.intent_data.merchant_name
 
   if !hasSavedCards {
     <PaymentMethod isScreenFocus paymentMethodData setConfirmButtonData />

--- a/src/pages/payment/SavedPaymentMethodSection.res
+++ b/src/pages/payment/SavedPaymentMethodSection.res
@@ -4,9 +4,7 @@ open Style
 @react.component
 let make = (~setConfirmButtonData, ~style=empty, ~isActive=false, ~setIsActive: bool => unit) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData} = AllApiDataContextNew.useData()
 
   let {
     bgColor,
@@ -20,41 +18,34 @@ let make = (~setConfirmButtonData, ~style=empty, ~isActive=false, ~setIsActive: 
   <UIUtils.RenderIf
     condition={nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.groupingBehavior.displayInSeparateSection &&
     !nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.groupingBehavior.displayInSeparateScreen}>
-    {switch clientData {
-    | Some(data) =>
-      <UIUtils.RenderIf
-        condition={data.customer_payment_methods->Array.length > 0}>
-        <Space />
-        <View
-          style={array([
-            bgColor,
-            getShadowStyle,
-            s({
-              borderWidth,
-              borderColor: component.borderColor,
-              borderRadius,
-              paddingHorizontal: 8.->dp,
-            }),
-            style,
-          ])}>
-          <TextWrapper
-            text="Saved"
-            textType=CardTextBold
-            overrideStyle={Some(s({marginTop: 16.->dp, marginBottom: 4.->dp, marginLeft: 12.->dp}))}
-          />
-          <SavedPaymentSheet
-            isScreenFocus=isActive
-            setIsScreenFocus=setIsActive
-            customerPaymentMethods=data.customer_payment_methods
-            setConfirmButtonData
-            merchantName={clientData
-            ->Option.map(data => data.intent_data.merchant_name)
-            ->Option.getOr(nativeProp.configuration.merchantDisplayName)}
-            animated=true
-          />
-        </View>
-      </UIUtils.RenderIf>
-    | None => React.null
-    }}
+    <UIUtils.RenderIf condition={clientData.customer_payment_methods->Array.length > 0}>
+      <Space />
+      <View
+        style={array([
+          bgColor,
+          getShadowStyle,
+          s({
+            borderWidth,
+            borderColor: component.borderColor,
+            borderRadius,
+            paddingHorizontal: 8.->dp,
+          }),
+          style,
+        ])}>
+        <TextWrapper
+          text="Saved"
+          textType=CardTextBold
+          overrideStyle={Some(s({marginTop: 16.->dp, marginBottom: 4.->dp, marginLeft: 12.->dp}))}
+        />
+        <SavedPaymentSheet
+          isScreenFocus=isActive
+          setIsScreenFocus=setIsActive
+          customerPaymentMethods=clientData.customer_payment_methods
+          setConfirmButtonData
+          merchantName=clientData.intent_data.merchant_name
+          animated=true
+        />
+      </View>
+    </UIUtils.RenderIf>
   </UIUtils.RenderIf>
 }

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -15,9 +15,7 @@ let make = (
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   let displayInSeparateScreen = nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.groupingBehavior.displayInSeparateScreen
-  let (clientData, sessionTokenData, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let {clientData, sessionTokenData} = AllApiDataContextNew.useData()
   let {getRequiredFieldsForButton, nickname} = React.useContext(
     DynamicFieldsContext.dynamicFieldsContext,
   )
@@ -101,9 +99,7 @@ let make = (
         ~nativeProp,
         ~payment_token=token.payment_token,
         ~payment_method_type=token.payment_method_type,
-        ~payment_type_str=clientData
-        ->Option.map(data => data.intent_data.payment_type_str)
-        ->Option.getOr(None),
+        ~payment_type_str=clientData.intent_data.payment_type_str,
       )
     } else {
       PaymentUtils.generateSavedCardConfirmBody(
@@ -111,9 +107,7 @@ let make = (
         ~payment_method=token.payment_method_str,
         ~payment_token=token.payment_token,
         ~savedCardCvv,
-        ~payment_type_str=clientData
-        ->Option.map(data => data.intent_data.payment_type_str)
-        ->Option.getOr(None),
+        ~payment_type_str=clientData.intent_data.payment_type_str,
         ~billing=token.billing,
         ~screen_height=viewPortContants.screenHeight,
         ~screen_width=viewPortContants.screenWidth,
@@ -211,22 +205,14 @@ let make = (
       ~payment_method_data=?CommonUtils.mergeDict(paymentMethodDataDict, tabDict)->Dict.get(
         "payment_method_data",
       ),
-      ~payment_type=clientData
-      ->Option.map(data => data.intent_data.payment_type)
-      ->Option.getOr(NORMAL),
-      ~payment_type_str=?clientData
-      ->Option.map(data => data.intent_data.payment_type_str)
-      ->Option.getOr(None),
-      ~appURL=?{
-        clientData->Option.map(data => data.intent_data.return_url)
-      },
+      ~payment_type=clientData.intent_data.payment_type,
+      ~payment_type_str=?clientData.intent_data.payment_type_str,
+      ~appURL=clientData.intent_data.return_url,
       ~isSaveCardCheckboxVisible={
         paymentMethodData.payment_method === CARD &&
           nativeProp.configuration.displaySavedPaymentMethodsCheckbox
       },
-      ~isGuestCustomer=clientData
-      ->Option.map(data => data.intent_data.is_guest_customer)
-      ->Option.getOr(true),
+      ~isGuestCustomer=clientData.intent_data.is_guest_customer,
       ~isNicknameSelected=false,
       ~email?,
       ~screen_height=viewPortContants.screenHeight,
@@ -317,29 +303,23 @@ let make = (
   // }, (country, paymentMethodData))
 
   let confirmGPay = var => {
-    switch clientData {
-    | Some(data) =>
-      let paymentMethodData =
-        data.payment_methods_enabled->Array.find(payment_method_type =>
-          payment_method_type.payment_method_type_wallet === GOOGLE_PAY
-        )
-      switch paymentMethodData {
-      | Some(paymentMethodData) =>
-        let status = handleWalletPayments(GOOGLE_PAY, var)
+    let paymentMethodData =
+      clientData.payment_methods_enabled->Array.find(payment_method_type =>
+        payment_method_type.payment_method_type_wallet === GOOGLE_PAY
+      )
+    switch paymentMethodData {
+    | Some(paymentMethodData) =>
+      let status = handleWalletPayments(GOOGLE_PAY, var)
 
-        switch status {
-        | Success(walletData, billingAddress, shippingAddress) =>
-          processWalletData(paymentMethodData, walletData, ~billingAddress?, ~shippingAddress?)
-        | Cancelled | Simulated =>
-          setLoading(FillingDetails)
-          showAlert(~errorType="warning", ~message="Payment was Cancelled")
-        | Failed(error_message) =>
-          setLoading(FillingDetails)
-          showAlert(~errorType="error", ~message=error_message)
-        }
-      | None =>
+      switch status {
+      | Success(walletData, billingAddress, shippingAddress) =>
+        processWalletData(paymentMethodData, walletData, ~billingAddress?, ~shippingAddress?)
+      | Cancelled | Simulated =>
         setLoading(FillingDetails)
-        showAlert(~errorType="error", ~message="Technical Error")
+        showAlert(~errorType="warning", ~message="Payment was Cancelled")
+      | Failed(error_message) =>
+        setLoading(FillingDetails)
+        showAlert(~errorType="error", ~message=error_message)
       }
     | None =>
       setLoading(FillingDetails)
@@ -348,48 +328,42 @@ let make = (
   }
 
   let confirmApplePay = (var: dict<JSON.t>) => {
-    switch clientData {
-    | Some(data) =>
-      let paymentMethodData =
-        data.payment_methods_enabled->Array.find(payment_method_type =>
-          payment_method_type.payment_method_type_wallet === APPLE_PAY
-        )
+    let paymentMethodData =
+      clientData.payment_methods_enabled->Array.find(payment_method_type =>
+        payment_method_type.payment_method_type_wallet === APPLE_PAY
+      )
 
-      switch paymentMethodData {
-      | Some(paymentMethodData) =>
-        logger(
-          ~logType=DEBUG,
-          ~value=paymentMethodData.payment_method_type,
-          ~category=USER_EVENT,
-          ~paymentMethod=paymentMethodData.payment_method_type,
-          ~eventName=APPLE_PAY_CALLBACK_FROM_NATIVE,
-          ~paymentExperience=paymentMethodData.payment_experience,
-          (),
-        )
+    switch paymentMethodData {
+    | Some(paymentMethodData) =>
+      logger(
+        ~logType=DEBUG,
+        ~value=paymentMethodData.payment_method_type,
+        ~category=USER_EVENT,
+        ~paymentMethod=paymentMethodData.payment_method_type,
+        ~eventName=APPLE_PAY_CALLBACK_FROM_NATIVE,
+        ~paymentExperience=paymentMethodData.payment_experience,
+        (),
+      )
 
-        let status = handleWalletPayments(APPLE_PAY, var)
+      let status = handleWalletPayments(APPLE_PAY, var)
 
-        switch status {
-        | Success(walletData, billingAddress, shippingAddress) =>
-          processWalletData(paymentMethodData, walletData, ~billingAddress?, ~shippingAddress?)
+      switch status {
+      | Success(walletData, billingAddress, shippingAddress) =>
+        processWalletData(paymentMethodData, walletData, ~billingAddress?, ~shippingAddress?)
 
-        | Cancelled =>
-          setLoading(FillingDetails)
-          showAlert(~errorType="warning", ~message="Cancelled")
-        | Simulated => setTimeout(() => {
-            setLoading(FillingDetails)
-            showAlert(
-              ~errorType="warning",
-              ~message="Apple Pay is not supported in Simulated Environment",
-            )
-          }, 2000)->ignore
-        | Failed(error_message) =>
-          setLoading(FillingDetails)
-          showAlert(~errorType="error", ~message=error_message)
-        }
-      | None =>
+      | Cancelled =>
         setLoading(FillingDetails)
-        showAlert(~errorType="error", ~message="Technical Error")
+        showAlert(~errorType="warning", ~message="Cancelled")
+      | Simulated => setTimeout(() => {
+          setLoading(FillingDetails)
+          showAlert(
+            ~errorType="warning",
+            ~message="Apple Pay is not supported in Simulated Environment",
+          )
+        }, 2000)->ignore
+      | Failed(error_message) =>
+        setLoading(FillingDetails)
+        showAlert(~errorType="error", ~message=error_message)
       }
     | None =>
       setLoading(FillingDetails)
@@ -411,10 +385,7 @@ let make = (
 
   // NOTE: To introduce a new component that shows Terms and conditions.
   // Terms list that proceeding with payment using card/ saved card/ wallet would save the payment method details
-  let showDisclaimer =
-    clientData
-    ->Option.map(data => data.intent_data.payment_type)
-    ->Option.getOr(NORMAL) !== NORMAL
+  let showDisclaimer = clientData.intent_data.payment_type !== NORMAL
 
   let onAbort = () => {
     setLoading(FillingDetails)

--- a/src/pages/widgets/ExpressCheckoutWidget.res
+++ b/src/pages/widgets/ExpressCheckoutWidget.res
@@ -7,9 +7,10 @@ open LoggerTypes
 let make = () => {
   let handleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
   let (nativeProp, setNativeProp) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
+  let customerPaymentMethods = switch AllApiDataContextNew.useOptionalData() {
+  | Some({clientData}) => clientData.customer_payment_methods
+  | None => []
+  }
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
   let (confirm, setConfirm) = React.useState(_ => false)
   let (savedCardCvv, setSavedCardCvv) = React.useState(_ => None)
@@ -47,29 +48,22 @@ let make = () => {
   // }
 
   let firstPaymentMethod = {
-    let pmList =
-      clientData->Option.map(data => data.customer_payment_methods)
     let platform = ReactNative.Platform.os
+    let first = customerPaymentMethods->Array.get(0)
 
-    pmList
-    ->Option.map(customer_payment_method_types => {
-      let first = customer_payment_method_types->Array.get(0)
+    let shouldUseNext = switch (platform, first) {
+    | (#android, Some(customer_payment_method_type)) =>
+      customer_payment_method_type.payment_method_type_wallet == SdkTypes.APPLE_PAY
+    | (#ios, Some(customer_payment_method_type)) =>
+      customer_payment_method_type.payment_method_type_wallet == SdkTypes.GOOGLE_PAY
+    | _ => false
+    }
 
-      let shouldUseNext = switch (platform, first) {
-      | (#android, Some(customer_payment_method_type)) =>
-        customer_payment_method_type.payment_method_type_wallet == SdkTypes.APPLE_PAY
-      | (#ios, Some(customer_payment_method_type)) =>
-        customer_payment_method_type.payment_method_type_wallet == SdkTypes.GOOGLE_PAY
-      | _ => false
-      }
-
-      if shouldUseNext && customer_payment_method_types->Array.length > 1 {
-        customer_payment_method_types->Array.get(1)
-      } else {
-        first
-      }
-    })
-    ->Option.getOr(None)
+    if shouldUseNext && customerPaymentMethods->Array.length > 1 {
+      customerPaymentMethods->Array.get(1)
+    } else {
+      first
+    }
   }
 
   let cardScheme =

--- a/src/routes/NavigationRouter.res
+++ b/src/routes/NavigationRouter.res
@@ -128,11 +128,23 @@ let make = () => {
     }
   }, (clientResponse, sdkConfigData, paymentMethodOrder, hiddenPaymentMethods))
 
+  let allApiData = React.useMemo3(() => {
+    switch (clientData, sdkConfigData) {
+    | (Some(clientData), Some(sdkConfigData)) =>
+      Some({
+        AllApiDataContextNew.clientData,
+        sdkConfigData,
+        sessionTokenData,
+      })
+    | _ => None
+    }
+  }, (clientData, sdkConfigData, sessionTokenData))
+
   BackHandlerHook.useBackHandler(~loading, ~sdkState=nativeProp.sdkState)
 
   UpdateIntentHook.useUpdateIntentListener(~setClientResponse, ~setSessionTokenData)
 
-  <AllApiDataContextNew clientData sessionTokenData sdkConfigData>
+  <AllApiDataContextNew allApiData>
     // TODO: Pass DynamicFieldsContext to only required components.
     // GO to NavigatorRouter.res and wrap only the components which require DynamicFieldsContext.
     <DynamicFieldsContext>

--- a/src/routes/NavigationRouter.res
+++ b/src/routes/NavigationRouter.res
@@ -175,6 +175,18 @@ let make = () => {
     }
   }, (clientResponse, sdkConfigData, paymentMethodOrder, hiddenPaymentMethods))
 
+  let allApiData = React.useMemo3(() => {
+    switch (clientData, sdkConfigData) {
+    | (Some(clientData), Some(sdkConfigData)) =>
+      Some({
+        AllApiDataContextNew.clientData,
+        sdkConfigData,
+        sessionTokenData,
+      })
+    | _ => None
+    }
+  }, (clientData, sdkConfigData, sessionTokenData))
+
   BackHandlerHook.useBackHandler(~loading, ~sdkState=nativeProp.sdkState)
 
   UpdateIntentHook.useUpdateIntentListener(
@@ -184,7 +196,7 @@ let make = () => {
     ~fetchedCredentialsKey,
   )
 
-  <AllApiDataContextNew clientData sessionTokenData sdkConfigData>
+  <AllApiDataContextNew allApiData>
     // TODO: Pass DynamicFieldsContext to only required components.
     // GO to NavigatorRouter.res and wrap only the components which require DynamicFieldsContext.
     <DynamicFieldsContext>

--- a/src/routes/ParentPaymentSheet.res
+++ b/src/routes/ParentPaymentSheet.res
@@ -1,14 +1,97 @@
+module SheetContent = {
+  @react.component
+  let make = (
+    ~isSavedPaymentScreen,
+    ~setIsSavedPaymentScreen,
+    ~confirmButtonData: GlobalConfirmButton.confirmButtonData,
+    ~setConfirmButtonData,
+  ) => {
+    let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+    let {clientData} = AllApiDataContextNew.useData()
+    let {sheetType} = React.useContext(DynamicFieldsContext.dynamicFieldsContext)
+
+    let (tabArr, elementArr, giftCardArr) = AllApiDataModifier.usePaymentMethodModifier()
+
+    let localeObject = GetLocale.useGetLocalObj()
+
+    let displayInSeparateScreen = nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.groupingBehavior.displayInSeparateScreen
+
+    React.useEffect1(() => {
+      if clientData.customer_payment_methods->Array.length === 0 {
+        setIsSavedPaymentScreen(false)
+      }
+      None
+    }, [clientData])
+
+    switch sheetType {
+    | ButtonSheet =>
+      switch (
+        nativeProp.sdkState,
+        !nativeProp.configuration.displaySavedPaymentMethods || !displayInSeparateScreen,
+      ) {
+      | (PaymentSheet, true)
+      | (WidgetPaymentSheet, true)
+      | (HostedCheckout, true)
+      | (TabSheet, true)
+      | (WidgetTabSheet, true)
+      | (ButtonSheet, _)
+      | (WidgetButtonSheet, _) =>
+        <PaymentSheet setConfirmButtonData isLoading=false tabArr elementArr giftCardArr />
+      | (PaymentSheet, false)
+      | (WidgetPaymentSheet, false)
+      | (HostedCheckout, false)
+      | (WidgetTabSheet, false)
+      | (TabSheet, false) =>
+        let customerPaymentMethods = clientData.customer_payment_methods
+        let showSavedScreen =
+          customerPaymentMethods->Array.length > 0 &&
+            clientData.intent_data.payment_type !== SETUP_MANDATE
+        <>
+          {isSavedPaymentScreen && showSavedScreen
+            ? <SavedPaymentSheet
+                customerPaymentMethods
+                setConfirmButtonData
+                merchantName=clientData.intent_data.merchant_name
+                maxVisibleItems=6
+                animated=true
+              />
+            : <PaymentSheet
+                setConfirmButtonData
+                isLoading=confirmButtonData.loading
+                tabArr
+                elementArr
+                giftCardArr
+              />}
+          <Space height=5. />
+          {showSavedScreen
+            ? <>
+                <Space height=5. />
+                <ClickableTextElement
+                  initialIconName="addwithcircle"
+                  updateIconName={Some("cardv1")}
+                  text={isSavedPaymentScreen
+                    ? localeObject.addPaymentMethodLabel
+                    : localeObject.useExisitingSavedCards}
+                  isSelected=isSavedPaymentScreen
+                  setIsSelected=setIsSavedPaymentScreen
+                  textType={TextWrapper.LinkTextBold}
+                  size=24.
+                />
+                <Space height=5. />
+              </>
+            : React.null}
+        </>
+      | _ => React.null
+      }
+    | DynamicFieldsSheet => <DynamicComponent setConfirmButtonData />
+    }
+  }
+}
+
 @react.component
 let make = () => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
-  let (clientData, _, _) = React.useContext(
-    AllApiDataContextNew.allApiDataContext,
-  )
-  let {sheetType} = React.useContext(DynamicFieldsContext.dynamicFieldsContext)
-
-  let (tabArr, elementArr, giftCardArr) = AllApiDataModifier.usePaymentMethodModifier()
-
-  let localeObject = GetLocale.useGetLocalObj()
+  let allApiData = AllApiDataContextNew.useOptionalData()
 
   let displayInSeparateScreen = nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.groupingBehavior.displayInSeparateScreen
 
@@ -26,24 +109,13 @@ let make = () => {
 
   UseWidgetActions.useWidgetActions(~confirmButtonData)
 
-  React.useEffect1(() => {
-    let hasNoSavedMethods = switch clientData {
-    | Some(data) => data.customer_payment_methods->Array.length === 0
-    | None => false
-    }
-    if hasNoSavedMethods {
-      setIsSavedPaymentScreen(false)
-    }
-    None
-  }, [clientData])
-
   let isLoading = React.useMemo2(() => {
     if nativeProp.configuration.allowsDelayedPaymentMethods {
-      !(clientData->Option.isSome)
+      !(allApiData->Option.isSome)
     } else {
       confirmButtonData.loading
     }
-  }, (clientData, confirmButtonData))
+  }, (allApiData, confirmButtonData))
 
   <FullScreenSheetWrapper
     isSavedPaymentScreen
@@ -52,83 +124,12 @@ let make = () => {
     stickyFooter=?{nativeProp.configuration.stickyPayButton
       ? Some(<GlobalConfirmButton confirmButtonData />)
       : None}>
-    {switch sheetType {
-    | ButtonSheet =>
-      switch (
-        nativeProp.sdkState,
-        !nativeProp.configuration.displaySavedPaymentMethods || !displayInSeparateScreen,
-      ) {
-      | (PaymentSheet, true)
-      | (WidgetPaymentSheet, true)
-      | (HostedCheckout, true)
-      | (TabSheet, true)
-      | (WidgetTabSheet, true)
-      | (ButtonSheet, _)
-      | (WidgetButtonSheet, _) =>
-        <PaymentSheet
-          setConfirmButtonData
-          isLoading={confirmButtonData.loading &&
-          clientData->Option.isNone}
-          tabArr
-          elementArr
-          giftCardArr
-        />
-      | (PaymentSheet, false)
-      | (WidgetPaymentSheet, false)
-      | (HostedCheckout, false)
-      | (WidgetTabSheet, false)
-      | (TabSheet, false) =>
-        switch clientData->Option.map(data =>
-          data.customer_payment_methods
-        ) {
-        | Some(customerPaymentMethods) =>
-          let showSavedScreen =
-            customerPaymentMethods->Array.length > 0 &&
-              clientData
-              ->Option.map(data => data.intent_data.payment_type)
-              ->Option.getOr(NORMAL) !== SETUP_MANDATE
-          <>
-            {isSavedPaymentScreen && showSavedScreen
-              ? <SavedPaymentSheet
-                  customerPaymentMethods
-                  setConfirmButtonData
-                  merchantName={clientData
-                  ->Option.map(data => data.intent_data.merchant_name)
-                  ->Option.getOr(nativeProp.configuration.merchantDisplayName)}
-                  maxVisibleItems=6
-                  animated=true
-                />
-              : <PaymentSheet
-                  setConfirmButtonData
-                  isLoading=confirmButtonData.loading
-                  tabArr
-                  elementArr
-                  giftCardArr
-                />}
-            <Space height=5. />
-            {showSavedScreen
-              ? <>
-                  <Space height=5. />
-                  <ClickableTextElement
-                    initialIconName="addwithcircle"
-                    updateIconName={Some("cardv1")}
-                    text={isSavedPaymentScreen
-                      ? localeObject.addPaymentMethodLabel
-                      : localeObject.useExisitingSavedCards}
-                    isSelected=isSavedPaymentScreen
-                    setIsSelected=setIsSavedPaymentScreen
-                    textType={TextWrapper.LinkTextBold}
-                    size=24.
-                  />
-                  <Space height=5. />
-                </>
-              : React.null}
-          </>
-        | None => <InitialLoader />
-        }
-      | _ => React.null
-      }
-    | DynamicFieldsSheet => <DynamicComponent setConfirmButtonData />
+    {switch allApiData {
+    | Some(_) =>
+      <SheetContent
+        isSavedPaymentScreen setIsSavedPaymentScreen confirmButtonData setConfirmButtonData
+      />
+    | None => <InitialLoader />
     }}
     <UIUtils.RenderIf condition={!nativeProp.configuration.stickyPayButton}>
       <GlobalConfirmButton confirmButtonData />


### PR DESCRIPTION
## Summary

  Refactors `AllApiDataContextNew` so components consuming payment data no longer need to repeatedly handle `clientData` and `sdkConfigData` as optional values.

  ## What changed

  - Replaced the context tuple:

    `(option<clientResponse>, option<sessions>, option<sdkConfig>)`

    with a single optional context record containing:

    - Required `clientData`
    - Required `sdkConfigData`
    - Optional `sessionTokenData`

  - Updated `NavigationRouter` to create the context value only after both the `/client` response and SDK configuration are available.

  - Split `ParentPaymentSheet` into:

    - A loading boundary that handles unavailable API data.
    - Data-dependent sheet content that consumes concrete values.

  - Added two context access patterns:

    - `useData` for components rendered after required data is available.
    - `useOptionalData` for top-level components that must also render during loading.

  - Updated payment methods, saved payment methods, dynamic fields, hosted checkout, confirm button, redirect flow, and express checkout consumers to use the new context structure.

  - Removed repeated `Option.map`, `Option.flatMap`, and `Option.getOr` operations for fields such as:

    - Payment type
    - Guest-customer status
    - Merchant name
    - Return URL
    - SDK next action
    - Customer payment methods

  - Kept session-token data optional because its failure is non-blocking.

  ## Why

  The `/client` response and SDK configuration are required before the payment UI can be constructed correctly. Previously, every consumer independently handled their absence and supplied fallback values.

  This resulted in duplicated optional handling and allowed components to temporarily consume fallback values while the required APIs were still loading.

  The new structure handles API-data availability at the rendering boundary and lets dependent components consume the actual response values directly.

  ## Behaviour

  - The payment-sheet loader remains visible until both client data and SDK configuration are available.
  - Components below the loading boundary receive concrete API data.
  - Components that render during loading continue to use optional access.
  - Session-token handling remains optional and non-blocking.
  - No API contracts, request construction, or response parsing have been changed.

  ## Validation

  - `npm run re:check`
  - `git diff --cached --check`