### PR TITLE
refactor: synchronize payment Id and API data during intent updates

### DIFF
--- a/src/headless/HeadlessUtils.res
+++ b/src/headless/HeadlessUtils.res
@@ -189,13 +189,7 @@ let getBaseUrl = nativeProp => {
 }
 
 let fetchClientData = nativeProp => {
-  let paymentId = switch nativeProp.paymentSessionConfig.sdkAuthorization {
-  | Some(auth) =>
-    Utils.getSdkAuthorizationData(auth).paymentId->Option.getOr(
-      nativeProp.paymentSessionConfig.paymentId,
-    )
-  | None => nativeProp.paymentSessionConfig.paymentId
-  }
+  let paymentId = nativeProp.paymentSessionConfig.paymentId
   let uri = Some(
     switch nativeProp.paymentSessionConfig.sdkAuthorization->Utils.getNonEmptyOption {
     | Some(_) => `${getBaseUrl(nativeProp)}/payments/${paymentId}/client`

--- a/src/hooks/AllPaymentHooks.res
+++ b/src/hooks/AllPaymentHooks.res
@@ -69,13 +69,7 @@ let useFetchClientData = () => {
     switch WebKit.platform {
     | #next => Promise.resolve(Next.clientResponse)
     | _ =>
-      let paymentId = switch nativeProp.paymentSessionConfig.sdkAuthorization {
-      | Some(auth) =>
-        Utils.getSdkAuthorizationData(auth).paymentId->Option.getOr(
-          nativeProp.paymentSessionConfig.paymentId,
-        )
-      | None => nativeProp.paymentSessionConfig.paymentId
-      }
+      let paymentId = nativeProp.paymentSessionConfig.paymentId
       let uri = switch nativeProp.paymentSessionConfig.sdkAuthorization->Utils.getNonEmptyOption {
       | Some(_) => `${baseUrl}/payments/${paymentId}/client`
       | None =>
@@ -133,14 +127,7 @@ let useSdkConfigHook = () => {
   let apiLogWrapper = LoggerHook.useApiLogWrapper()
   let baseUrl = GlobalHooks.useGetBaseUrl()()
   () => {
-    let clientSecret = switch nativeProp.paymentSessionConfig.sdkAuthorization {
-    | Some(auth) =>
-      Utils.getSdkAuthorizationData(auth).clientSecret->Option.getOr(
-        nativeProp.paymentSessionConfig.clientSecret,
-      )
-    | None => nativeProp.paymentSessionConfig.clientSecret
-    }
-    let uri = `${baseUrl}/v1/sdk/configs/${WebKit.platformGroup}/sdk_config.json?client_secret=${clientSecret}`
+    let uri = `${baseUrl}/v1/sdk/configs/${WebKit.platformGroup}/sdk_config.json?client_secret=${nativeProp.paymentSessionConfig.clientSecret}`
 
     APIUtils.fetchApiWrapper(
       ~uri,

--- a/src/hooks/UpdateIntentHook.res
+++ b/src/hooks/UpdateIntentHook.res
@@ -3,11 +3,18 @@ open SdkTypes
 let updateIntentInitReturned = "UPDATE_INTENT_INIT_RETURNED"
 let updateIntentCompleteReturned = "UPDATE_INTENT_COMPLETE_RETURNED"
 
-let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
+let useUpdateIntentListener = (
+  ~setClientResponse,
+  ~setSessionTokenData,
+  ~setSdkConfigData,
+  ~fetchedCredentialsKey: React.ref<option<string>>,
+) => {
   let (nativeProp, setNativeProp) = React.useContext(NativePropContext.nativePropContext)
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
   let apiLogWrapper = LoggerHook.useApiLogWrapper()
   let baseUrl = GlobalHooks.useGetBaseUrl()()
+
+  let updateRequestIdRef = React.useRef(0)
 
   let nativePropRef = React.useRef(nativeProp)
 
@@ -78,69 +85,26 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
         ) {
           switch intentData.sdkAuthorization {
           | Some(sdkAuth) if sdkAuth !== "" =>
-            // Update nativeProp with new sdkAuthorization
-            // This triggers a re-render and the NavigationRouter effect will refetch
-            setNativeProp({
+            let authData = Utils.getSdkAuthorizationData(sdkAuth)
+            let paymentId =
+              authData.paymentId->Option.getOr(currentNativeProp.paymentSessionConfig.paymentId)
+            let clientSecret =
+              authData.clientSecret->Option.getOr(
+                currentNativeProp.paymentSessionConfig.clientSecret,
+              )
+
+            let updatedNativeProp = {
               ...currentNativeProp,
               paymentSessionConfig: {
-                ...currentNativeProp.paymentSessionConfig,
+                clientSecret,
                 sdkAuthorization: Some(sdkAuth),
+                paymentId,
               },
-            })
-
-            let hasError = ref(false)
-
-            let handleClientResponse = clientResp => {
-              if ErrorUtils.isError(clientResp) {
-                hasError := true
-                HyperModule.onUpdateIntentEvent(
-                  currentNativeProp.rootTag,
-                  updateIntentCompleteReturned,
-                  JSON.stringify(
-                    JSON.Encode.object(
-                      Dict.fromArray([
-                        ("status", JSON.Encode.string("failed")),
-                        ("code", JSON.Encode.string("combine_pml_error")),
-                        ("message", JSON.Encode.string(ErrorUtils.getErrorMessage(clientResp))),
-                      ]),
-                    ),
-                  ),
-                )
-              } else if clientResp == JSON.Encode.null {
-                hasError := true
-                HyperModule.onUpdateIntentEvent(
-                  currentNativeProp.rootTag,
-                  updateIntentCompleteReturned,
-                  JSON.stringify(
-                    JSON.Encode.object(
-                      Dict.fromArray([
-                        ("status", JSON.Encode.string("failed")),
-                        ("code", JSON.Encode.string("no_payment_methods_found")),
-                        ("message", JSON.Encode.string("No payment methods found")),
-                      ]),
-                    ),
-                  ),
-                )
-              } else {
-                setClientResponse(_ => Some(clientResp))
-              }
             }
 
-            let handleSessionTokenResponse = sessionTokenData => {
-              if !(sessionTokenData->ErrorUtils.isError) && sessionTokenData != JSON.Null {
-                switch sessionTokenData->SessionsType.jsonToSessionTokenType {
-                | Some(sessions) => setSessionTokenData(_ => Some(sessions))
-                | None => setSessionTokenData(_ => Some([]))
-                }
-              }
-            }
+            updateRequestIdRef.current = updateRequestIdRef.current + 1
+            let requestId = updateRequestIdRef.current
 
-            // Use AllPaymentHooks for API calls
-            // These hooks read sdkAuthorization from context, so we need to call them after
-            // the context update takes effect. Since the context update is async (setNativeProp),
-            // we need to call the hooks directly with the new sdkAuth.
-
-            // Build headers and URIs with new sdkAuthorization
             let headers = Utils.getHeader(
               ~apiKey=currentNativeProp.hyperswitchConfig.publishableKey,
               ~appId=currentNativeProp.sdkParams.appId,
@@ -148,16 +112,24 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
               (),
             )
 
-            let paymentId =
-              Utils.getSdkAuthorizationData(sdkAuth).paymentId->Option.getOr(
-                currentNativeProp.paymentSessionConfig.paymentId,
+            let failUpdate = (~code, ~message) =>
+              HyperModule.onUpdateIntentEvent(
+                currentNativeProp.rootTag,
+                updateIntentCompleteReturned,
+                JSON.stringify(
+                  JSON.Encode.object(
+                    Dict.fromArray([
+                      ("status", JSON.Encode.string("failed")),
+                      ("code", JSON.Encode.string(code)),
+                      ("message", JSON.Encode.string(message)),
+                    ]),
+                  ),
+                ),
               )
 
-            let clientUri = `${baseUrl}/payments/${paymentId}/client`
-
-            Promise.all2((
+            Promise.all3((
               APIUtils.fetchApiWrapper(
-                ~uri=clientUri,
+                ~uri=`${baseUrl}/payments/${paymentId}/client`,
                 ~method=#GET,
                 ~headers,
                 ~eventName=LoggerTypes.CLIENT_LIST_CALL,
@@ -167,7 +139,7 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
               APIUtils.fetchApiWrapper(
                 ~uri=`${baseUrl}/payments/session_tokens`,
                 ~body=PaymentUtils.generateSessionsTokenBody(
-                  ~clientSecret=currentNativeProp.paymentSessionConfig.clientSecret,
+                  ~clientSecret,
                   ~paymentId,
                   ~sdkAuthorization=sdkAuth,
                   ~wallet=[],
@@ -177,16 +149,74 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
                 ~eventName=LoggerTypes.SESSIONS_CALL,
                 ~apiLogWrapper,
               ),
+              APIUtils.fetchApiWrapper(
+                ~uri=`${baseUrl}/v1/sdk/configs/${WebKit.platformGroup}/sdk_config.json?client_secret=${clientSecret}`,
+                ~method=#GET,
+                ~headers,
+                ~eventName=LoggerTypes.CONFIG_CALL,
+                ~apiLogWrapper,
+              ),
             ))
             ->Promise.then(
-              ((clientResp, sessionTokenData)) => {
-                handleClientResponse(clientResp)
-                handleSessionTokenResponse(sessionTokenData)
+              ((clientResp, sessionTokenResp, configResp)) => {
+                if updateRequestIdRef.current !== requestId {
+                  failUpdate(
+                    ~code="superseded_by_newer_update",
+                    ~message="A newer update intent request superseded this one",
+                  )
+                  Promise.resolve()
+                } else {
+                let clientError = if ErrorUtils.isError(clientResp) {
+                  Some(("client_api_error", ErrorUtils.getErrorMessage(clientResp)))
+                } else if clientResp == JSON.Encode.null {
+                  Some(("no_payment_methods_found", "No payment methods found"))
+                } else {
+                  let dict = clientResp->Utils.getDictFromJson
+                  let hasEnabledMethods =
+                    dict->Utils.getArray("payment_methods_enabled")->Array.length > 0
+                  let hasSavedMethods =
+                    dict->Utils.getArray("customer_payment_methods")->Array.length > 0
+                  hasEnabledMethods || hasSavedMethods
+                    ? None
+                    : Some(("no_payment_methods_found", "No payment methods found"))
+                }
 
-                setLoading(FillingDetails)
+                let configResult = if (
+                  ErrorUtils.isError(configResp) || configResp == JSON.Encode.null
+                ) {
+                  Error()
+                } else {
+                  let parsed = SdkConfigParser.itemToObjMapper(configResp)
+                  PaymentUtils.isValidSdkConfig(parsed) ? Ok(parsed) : Error()
+                }
 
-                // Only send success if there was no error
-                if !hasError.contents {
+                switch (clientError, configResult) {
+                | (Some((code, message)), _) => failUpdate(~code, ~message)
+                | (None, Error()) =>
+                  failUpdate(
+                    ~code="sdk_config_failed",
+                    ~message="Unable to load the payment configuration",
+                  )
+                | (None, Ok(parsedConfig)) =>
+                  let newSessions = if (
+                    !(sessionTokenResp->ErrorUtils.isError) && sessionTokenResp != JSON.Null
+                  ) {
+                    switch sessionTokenResp->SessionsType.jsonToSessionTokenType {
+                    | Some(sessions) => Some(sessions)
+                    | None => Some([])
+                    }
+                  } else {
+                    None
+                  }
+
+                  fetchedCredentialsKey.current = Some(
+                    PaymentUtils.getSessionCredentialsKey(updatedNativeProp),
+                  )
+                  setNativeProp(updatedNativeProp)
+                  setClientResponse(_ => Some(clientResp))
+                  setSdkConfigData(_ => Some(parsedConfig))
+                  setSessionTokenData(_ => newSessions)
+
                   HyperModule.onUpdateIntentEvent(
                     currentNativeProp.rootTag,
                     updateIntentCompleteReturned,
@@ -197,25 +227,23 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
                     ),
                   )
                 }
+
+                setLoading(FillingDetails)
                 Promise.resolve()
+                }
               },
             )
             ->Promise.catch(
               _err => {
-                setLoading(FillingDetails)
-                HyperModule.onUpdateIntentEvent(
-                  currentNativeProp.rootTag,
-                  updateIntentCompleteReturned,
-                  JSON.stringify(
-                    JSON.Encode.object(
-                      Dict.fromArray([
-                        ("status", JSON.Encode.string("failed")),
-                        ("code", JSON.Encode.string("api_call_failed")),
-                        ("message", JSON.Encode.string("API call failed")),
-                      ]),
-                    ),
-                  ),
-                )
+                if updateRequestIdRef.current === requestId {
+                  setLoading(FillingDetails)
+                  failUpdate(~code="api_call_failed", ~message="API call failed")
+                } else {
+                  failUpdate(
+                    ~code="superseded_by_newer_update",
+                    ~message="A newer update intent request superseded this one",
+                  )
+                }
                 Promise.resolve()
               },
             )

--- a/src/hooks/UpdateIntentHook.res
+++ b/src/hooks/UpdateIntentHook.res
@@ -3,11 +3,18 @@ open SdkTypes
 let updateIntentInitReturned = "UPDATE_INTENT_INIT_RETURNED"
 let updateIntentCompleteReturned = "UPDATE_INTENT_COMPLETE_RETURNED"
 
-let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
+let useUpdateIntentListener = (
+  ~setClientResponse,
+  ~setSessionTokenData,
+  ~setSdkConfigData,
+  ~fetchedCredentialsKey: React.ref<option<string>>,
+) => {
   let (nativeProp, setNativeProp) = React.useContext(NativePropContext.nativePropContext)
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
   let apiLogWrapper = LoggerHook.useApiLogWrapper()
   let baseUrl = GlobalHooks.useGetBaseUrl()()
+
+  let updateRequestIdRef = React.useRef(0)
 
   let nativePropRef = React.useRef(nativeProp)
 
@@ -67,61 +74,26 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
         ) {
           switch intentData.sdkAuthorization {
           | Some(sdkAuth) if sdkAuth !== "" =>
-            // Update nativeProp with new sdkAuthorization
-            // This triggers a re-render and the NavigationRouter effect will refetch
-            setNativeProp({
+            let authData = Utils.getSdkAuthorizationData(sdkAuth)
+            let paymentId =
+              authData.paymentId->Option.getOr(currentNativeProp.paymentSessionConfig.paymentId)
+            let clientSecret =
+              authData.clientSecret->Option.getOr(
+                currentNativeProp.paymentSessionConfig.clientSecret,
+              )
+
+            let updatedNativeProp = {
               ...currentNativeProp,
               paymentSessionConfig: {
-                ...currentNativeProp.paymentSessionConfig,
+                clientSecret,
                 sdkAuthorization: Some(sdkAuth),
+                paymentId,
               },
-            })
-
-            let hasError = ref(false)
-
-            let handleClientResponse = clientResp => {
-              if ErrorUtils.isError(clientResp) {
-                hasError := true
-                HyperModule.onUpdateIntentEvent(
-                  currentNativeProp.rootTag,
-                  updateIntentCompleteReturned,
-                  {
-                    status: "failed",
-                    code: "combine_pml_error",
-                    message: ErrorUtils.getErrorMessage(clientResp),
-                  },
-                )
-              } else if clientResp == JSON.Encode.null {
-                hasError := true
-                HyperModule.onUpdateIntentEvent(
-                  currentNativeProp.rootTag,
-                  updateIntentCompleteReturned,
-                  {
-                    status: "failed",
-                    code: "no_payment_methods_found",
-                    message: "No payment methods found",
-                  },
-                )
-              } else {
-                setClientResponse(_ => Some(clientResp))
-              }
             }
 
-            let handleSessionTokenResponse = sessionTokenData => {
-              if !(sessionTokenData->ErrorUtils.isError) && sessionTokenData != JSON.Null {
-                switch sessionTokenData->SessionsType.jsonToSessionTokenType {
-                | Some(sessions) => setSessionTokenData(_ => Some(sessions))
-                | None => setSessionTokenData(_ => Some([]))
-                }
-              }
-            }
+            updateRequestIdRef.current = updateRequestIdRef.current + 1
+            let requestId = updateRequestIdRef.current
 
-            // Use AllPaymentHooks for API calls
-            // These hooks read sdkAuthorization from context, so we need to call them after
-            // the context update takes effect. Since the context update is async (setNativeProp),
-            // we need to call the hooks directly with the new sdkAuth.
-
-            // Build headers and URIs with new sdkAuthorization
             let headers = Utils.getHeader(
               ~apiKey=currentNativeProp.hyperswitchConfig.publishableKey,
               ~appId=currentNativeProp.sdkParams.appId,
@@ -129,16 +101,16 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
               (),
             )
 
-            let paymentId =
-              Utils.getSdkAuthorizationData(sdkAuth).paymentId->Option.getOr(
-                currentNativeProp.paymentSessionConfig.paymentId,
+            let failUpdate = (~code, ~message) =>
+              HyperModule.onUpdateIntentEvent(
+                currentNativeProp.rootTag,
+                updateIntentCompleteReturned,
+                {status: "failed", code, message},
               )
 
-            let clientUri = `${baseUrl}/payments/${paymentId}/client`
-
-            Promise.all2((
+            Promise.all3((
               APIUtils.fetchApiWrapper(
-                ~uri=clientUri,
+                ~uri=`${baseUrl}/payments/${paymentId}/client`,
                 ~method=#GET,
                 ~headers,
                 ~eventName=LoggerTypes.CLIENT_LIST_CALL,
@@ -148,7 +120,7 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
               APIUtils.fetchApiWrapper(
                 ~uri=`${baseUrl}/payments/session_tokens`,
                 ~body=PaymentUtils.generateSessionsTokenBody(
-                  ~clientSecret=currentNativeProp.paymentSessionConfig.clientSecret,
+                  ~clientSecret,
                   ~paymentId,
                   ~sdkAuthorization=sdkAuth,
                   ~wallet=[],
@@ -158,33 +130,97 @@ let useUpdateIntentListener = (~setClientResponse, ~setSessionTokenData) => {
                 ~eventName=LoggerTypes.SESSIONS_CALL,
                 ~apiLogWrapper,
               ),
+              APIUtils.fetchApiWrapper(
+                ~uri=`${baseUrl}/v1/sdk/configs/${WebKit.platformGroup}/sdk_config.json?client_secret=${clientSecret}`,
+                ~method=#GET,
+                ~headers,
+                ~eventName=LoggerTypes.CONFIG_CALL,
+                ~apiLogWrapper,
+              ),
             ))
             ->Promise.then(
-              ((clientResp, sessionTokenData)) => {
-                handleClientResponse(clientResp)
-                handleSessionTokenResponse(sessionTokenData)
+              ((clientResp, sessionTokenResp, configResp)) => {
+                if updateRequestIdRef.current !== requestId {
+                  failUpdate(
+                    ~code="superseded_by_newer_update",
+                    ~message="A newer update intent request superseded this one",
+                  )
+                  Promise.resolve()
+                } else {
+                let clientError = if ErrorUtils.isError(clientResp) {
+                  Some(("client_api_error", ErrorUtils.getErrorMessage(clientResp)))
+                } else if clientResp == JSON.Encode.null {
+                  Some(("no_payment_methods_found", "No payment methods found"))
+                } else {
+                  let dict = clientResp->Utils.getDictFromJson
+                  let hasEnabledMethods =
+                    dict->Utils.getArray("payment_methods_enabled")->Array.length > 0
+                  let hasSavedMethods =
+                    dict->Utils.getArray("customer_payment_methods")->Array.length > 0
+                  hasEnabledMethods || hasSavedMethods
+                    ? None
+                    : Some(("no_payment_methods_found", "No payment methods found"))
+                }
 
-                setLoading(FillingDetails)
+                let configResult = if (
+                  ErrorUtils.isError(configResp) || configResp == JSON.Encode.null
+                ) {
+                  Error()
+                } else {
+                  let parsed = SdkConfigParser.itemToObjMapper(configResp)
+                  PaymentUtils.isValidSdkConfig(parsed) ? Ok(parsed) : Error()
+                }
 
-                // Only send success if there was no error
-                if !hasError.contents {
+                switch (clientError, configResult) {
+                | (Some((code, message)), _) => failUpdate(~code, ~message)
+                | (None, Error()) =>
+                  failUpdate(
+                    ~code="sdk_config_failed",
+                    ~message="Unable to load the payment configuration",
+                  )
+                | (None, Ok(parsedConfig)) =>
+                  let newSessions = if (
+                    !(sessionTokenResp->ErrorUtils.isError) && sessionTokenResp != JSON.Null
+                  ) {
+                    switch sessionTokenResp->SessionsType.jsonToSessionTokenType {
+                    | Some(sessions) => Some(sessions)
+                    | None => Some([])
+                    }
+                  } else {
+                    None
+                  }
+
+                  fetchedCredentialsKey.current = Some(
+                    PaymentUtils.getSessionCredentialsKey(updatedNativeProp),
+                  )
+                  setNativeProp(updatedNativeProp)
+                  setClientResponse(_ => Some(clientResp))
+                  setSdkConfigData(_ => Some(parsedConfig))
+                  setSessionTokenData(_ => newSessions)
+
                   HyperModule.onUpdateIntentEvent(
                     currentNativeProp.rootTag,
                     updateIntentCompleteReturned,
                     {status: "success"},
                   )
                 }
+
+                setLoading(FillingDetails)
                 Promise.resolve()
+                }
               },
             )
             ->Promise.catch(
               _err => {
-                setLoading(FillingDetails)
-                HyperModule.onUpdateIntentEvent(
-                  currentNativeProp.rootTag,
-                  updateIntentCompleteReturned,
-                  {status: "failed", code: "api_call_failed", message: "API call failed"},
-                )
+                if updateRequestIdRef.current === requestId {
+                  setLoading(FillingDetails)
+                  failUpdate(~code="api_call_failed", ~message="API call failed")
+                } else {
+                  failUpdate(
+                    ~code="superseded_by_newer_update",
+                    ~message="A newer update intent request superseded this one",
+                  )
+                }
                 Promise.resolve()
               },
             )

--- a/src/pages/widgets/ExpressCheckoutWidget.res
+++ b/src/pages/widgets/ExpressCheckoutWidget.res
@@ -277,6 +277,10 @@ let make = () => {
         paymentSessionConfig: {
           ...nativeProp.paymentSessionConfig,
           clientSecret: responseFromJava.clientSecret,
+          paymentId: responseFromJava.clientSecret
+          ->String.split("_secret_")
+          ->Array.get(0)
+          ->Option.getOr(""),
         },
         configuration: {
           ...nativeProp.configuration,

--- a/src/routes/NavigationRouter.res
+++ b/src/routes/NavigationRouter.res
@@ -1,10 +1,3 @@
-let isValidConfig = (value: SdkConfigTypes.sdkConfigValue) =>
-  switch value.raw_configs->Option.flatMap(JSON.Decode.object) {
-  | Some(dict) =>
-    dict->Dict.get("default_configs")->Option.isSome || dict->Dict.get("contexts")->Option.isSome
-  | None => false
-  }
-
 @react.component
 let make = () => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
@@ -23,25 +16,71 @@ let make = () => {
   let errorOnApiCalls = ErrorHooks.useShowErrorOrWarning()
   let logger = LoggerHook.useLoggerHook()
 
+  let isDismissableSheet = switch nativeProp.sdkState {
+  | PaymentSheet
+  | TabSheet
+  | ButtonSheet
+  | HostedCheckout
+  | WidgetPaymentSheet
+  | WidgetTabSheet
+  | WidgetButtonSheet => true
+  | _ => false
+  }
+
   React.useEffect1(() => {
     let launchTime = nativeProp.sdkParams.launchTime->Option.getOr(Date.now())
     let latency = Date.now() -. launchTime
     let appId = nativeProp.sdkParams.appId->Option.getOr("") ++ ".hyperswitch://"
     logger(~logType=INFO, ~value=appId, ~category=USER_EVENT, ~eventName=APP_RENDERED, ~latency, ())
     error()
+    None
+  }, [nativeProp])
 
+  let sessionCredentialsKey = PaymentUtils.getSessionCredentialsKey(nativeProp)
+  let fetchedCredentialsKey = React.useRef(None)
+
+  React.useEffect1(() => {
     //KountModule.launchKountIfAvailable(nativeProp.paymentSessionConfig.clientSecret, _x => ())
-    // if (nativeProp.paymentSessionConfig.clientSecret != "" || nativeProp.paymentMethodId != "") &&
-    //   nativeProp.hyperswitchConfig.publishableKey != ""
-    if nativeProp.sdkState !== CvcWidget {
+    let alreadyFetched = switch fetchedCredentialsKey.current {
+    | Some(key) => key === sessionCredentialsKey
+    | None => false
+    }
+    if nativeProp.sdkState !== CvcWidget && !alreadyFetched {
+      fetchedCredentialsKey.current = Some(sessionCredentialsKey)
+      let requestKey = sessionCredentialsKey
+
+      let isRequestCurrent = () =>
+        switch fetchedCredentialsKey.current {
+        | Some(key) => key === requestKey
+        | None => false
+        }
+
+      let terminalErrorFired = ref(false)
+      let exitSheetOnce = (~apiResStatus) =>
+        if !terminalErrorFired.contents {
+          terminalErrorFired := true
+          handleSuccessFailure(~apiResStatus, ())
+        }
+
       let handleClientResponse = clientResp => {
         if ErrorUtils.isError(clientResp) {
-          errorOnApiCalls(
-            INVALID_PK((Error, Static(ErrorUtils.getErrorMessage(clientResp)))),
-            (),
-          )
+          if isDismissableSheet {
+            exitSheetOnce(
+              ~apiResStatus={
+                type_: "",
+                status: "failed",
+                code: "client_api_error",
+                message: ErrorUtils.getErrorMessage(clientResp),
+              },
+            )
+          } else {
+            errorOnApiCalls(
+              INVALID_PK((Error, Static(ErrorUtils.getErrorMessage(clientResp)))),
+              (),
+            )
+          }
         } else if clientResp == JSON.Encode.null {
-          handleSuccessFailure(~apiResStatus=PaymentConfirmTypes.defaultConfirmError, ())
+          exitSheetOnce(~apiResStatus=PaymentConfirmTypes.defaultConfirmError)
         } else {
           // Both lists now arrive in ONE response, so an empty payment_methods_enabled
           // must not discard the customer's saved methods carried alongside it. Either
@@ -51,6 +90,8 @@ let make = () => {
           let hasSavedMethods = dict->Utils.getArray("customer_payment_methods")->Array.length > 0
           if hasEnabledMethods || hasSavedMethods {
             setClientResponse(_ => Some(clientResp))
+          } else if isDismissableSheet {
+            exitSheetOnce(~apiResStatus=PaymentConfirmTypes.defaultNoPaymentMethodsError)
           } else {
             errorOnApiCalls(ErrorUtils.errorWarning.noPMLData, ())
           }
@@ -63,31 +104,33 @@ let make = () => {
           // config failure means the sheet cannot render/confirm correctly.
           // Treat it as terminal (like the null/invalid cases below) instead of a
           // non-blocking alert — otherwise the config-gated memo strands the UI.
-          handleSuccessFailure(~apiResStatus=PaymentConfirmTypes.defaultConfigError, ())
+          exitSheetOnce(~apiResStatus=PaymentConfirmTypes.defaultConfigError)
         } else if configResponse == JSON.Encode.null {
-          handleSuccessFailure(~apiResStatus=PaymentConfirmTypes.defaultConfigError, ())
+          exitSheetOnce(~apiResStatus=PaymentConfirmTypes.defaultConfigError)
         } else {
           let parsed = SdkConfigParser.itemToObjMapper(configResponse)
-          if isValidConfig(parsed) {
+          if PaymentUtils.isValidSdkConfig(parsed) {
             setSdkConfigData(_ => Some(parsed))
           } else {
-            handleSuccessFailure(~apiResStatus=PaymentConfirmTypes.defaultConfigError, ())
+            exitSheetOnce(~apiResStatus=PaymentConfirmTypes.defaultConfigError)
           }
         }
       }
 
       sessionToken()
       ->Promise.then(sessionTokenData => {
-        if sessionTokenData->ErrorUtils.isError {
-          if sessionTokenData->ErrorUtils.getErrorCode == "\"IR_16\"" {
-            errorOnApiCalls(ErrorUtils.errorWarning.usedCL, ())
-          } else if sessionTokenData->ErrorUtils.getErrorCode == "\"IR_09\"" {
-            errorOnApiCalls(ErrorUtils.errorWarning.invalidCL, ())
-          }
-        } else if sessionTokenData != JSON.Null {
-          switch sessionTokenData->SessionsType.jsonToSessionTokenType {
-          | Some(sessions) => setSessionTokenData(_ => Some(sessions))
-          | None => setSessionTokenData(_ => Some([]))
+        if isRequestCurrent() {
+          if sessionTokenData->ErrorUtils.isError {
+            if sessionTokenData->ErrorUtils.getErrorCode == "\"IR_16\"" {
+              errorOnApiCalls(ErrorUtils.errorWarning.usedCL, ())
+            } else if sessionTokenData->ErrorUtils.getErrorCode == "\"IR_09\"" {
+              errorOnApiCalls(ErrorUtils.errorWarning.invalidCL, ())
+            }
+          } else if sessionTokenData != JSON.Null {
+            switch sessionTokenData->SessionsType.jsonToSessionTokenType {
+            | Some(sessions) => setSessionTokenData(_ => Some(sessions))
+            | None => setSessionTokenData(_ => Some([]))
+            }
           }
         }
         Promise.resolve()
@@ -96,20 +139,24 @@ let make = () => {
 
       sdkConfig()
       ->Promise.then(configResponse => {
-        handleSdkConfigResponse(configResponse)
+        if isRequestCurrent() {
+          handleSdkConfigResponse(configResponse)
+        }
         Promise.resolve()
       })
       ->ignore
 
       fetchClientData()
       ->Promise.then(clientResp => {
-        handleClientResponse(clientResp)
+        if isRequestCurrent() {
+          handleClientResponse(clientResp)
+        }
         Promise.resolve()
       })
       ->ignore
     }
     None
-  }, [nativeProp])
+  }, [sessionCredentialsKey])
 
   let paymentMethodOrder = nativeProp.configuration.paymentMethodOrder
   let hiddenPaymentMethods = nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.hiddenPaymentMethods
@@ -130,7 +177,12 @@ let make = () => {
 
   BackHandlerHook.useBackHandler(~loading, ~sdkState=nativeProp.sdkState)
 
-  UpdateIntentHook.useUpdateIntentListener(~setClientResponse, ~setSessionTokenData)
+  UpdateIntentHook.useUpdateIntentListener(
+    ~setClientResponse,
+    ~setSessionTokenData,
+    ~setSdkConfigData,
+    ~fetchedCredentialsKey,
+  )
 
   <AllApiDataContextNew clientData sessionTokenData sdkConfigData>
     // TODO: Pass DynamicFieldsContext to only required components.

--- a/src/types/AllApiDataTypes/PaymentConfirmTypes.res
+++ b/src/types/AllApiDataTypes/PaymentConfirmTypes.res
@@ -93,6 +93,13 @@ let defaultConfigError = {
   message: "Unable to load the payment configuration. Please retry.",
 }
 
+let defaultNoPaymentMethodsError = {
+  type_: "",
+  status: "failed",
+  code: "no_payment_methods_found",
+  message: "No payment methods found",
+}
+
 let defaultCancelError = {
   type_: "",
   status: "cancelled",

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -852,18 +852,19 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
   let ps = getObj(d, "paymentSessionConfig", Dict.make())
   let sp = getObj(d, "sdkParams", Dict.make())
 
-  let clientSecret = getString(ps, "clientSecret", "")
   let sdkAuthorization = switch getOptionString(ps, "sdkAuthorization") {
   | Some("") | None => None
   | v => v
   }
-  let paymentId = switch sdkAuthorization {
-  | Some(auth) =>
-    Utils.getSdkAuthorizationData(auth).paymentId->Option.getOr(
-      clientSecret->String.split("_secret_")->Array.get(0)->Option.getOr(""),
-    )
-  | None => clientSecret->String.split("_secret_")->Array.get(0)->Option.getOr("")
-  }
+  let sdkAuthorizationData = sdkAuthorization->Option.map(Utils.getSdkAuthorizationData)
+  let clientSecret =
+    sdkAuthorizationData
+    ->Option.flatMap(data => data.clientSecret)
+    ->Option.getOr(getString(ps, "clientSecret", ""))
+  let paymentId =
+    sdkAuthorizationData
+    ->Option.flatMap(data => data.paymentId)
+    ->Option.getOr(clientSecret->String.split("_secret_")->Array.get(0)->Option.getOr(""))
 
   {
     rootTag,

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -854,18 +854,19 @@ let nativeJsonToRecord = (jsonFromNative, rootTag) => {
   let ps = getObj(d, "paymentSessionConfig", Dict.make())
   let sp = getObj(d, "sdkParams", Dict.make())
 
-  let clientSecret = getString(ps, "clientSecret", "")
   let sdkAuthorization = switch getOptionString(ps, "sdkAuthorization") {
   | Some("") | None => None
   | v => v
   }
-  let paymentId = switch sdkAuthorization {
-  | Some(auth) =>
-    Utils.getSdkAuthorizationData(auth).paymentId->Option.getOr(
-      clientSecret->String.split("_secret_")->Array.get(0)->Option.getOr(""),
-    )
-  | None => clientSecret->String.split("_secret_")->Array.get(0)->Option.getOr("")
-  }
+  let sdkAuthorizationData = sdkAuthorization->Option.map(Utils.getSdkAuthorizationData)
+  let clientSecret =
+    sdkAuthorizationData
+    ->Option.flatMap(data => data.clientSecret)
+    ->Option.getOr(getString(ps, "clientSecret", ""))
+  let paymentId =
+    sdkAuthorizationData
+    ->Option.flatMap(data => data.paymentId)
+    ->Option.getOr(clientSecret->String.split("_secret_")->Array.get(0)->Option.getOr(""))
 
   {
     rootTag,

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -204,3 +204,15 @@ let getCardNetworks = cardNetworks => {
   | None => []
   }
 }
+
+let isValidSdkConfig = (value: SdkConfigTypes.sdkConfigValue) =>
+  switch value.raw_configs->Option.flatMap(JSON.Decode.object) {
+  | Some(dict) =>
+    dict->Dict.get("default_configs")->Option.isSome || dict->Dict.get("contexts")->Option.isSome
+  | None => false
+  }
+
+let getSessionCredentialsKey = (nativeProp: SdkTypes.nativeProp) =>
+  `${nativeProp.hyperswitchConfig.publishableKey}|${nativeProp.paymentSessionConfig.paymentId}|${nativeProp.paymentSessionConfig.clientSecret}|${nativeProp.paymentSessionConfig.sdkAuthorization->Option.getOr(
+      "",
+    )}`


### PR DESCRIPTION
## Summary

  This PR improves client-response parsing and removes parser behavior that is unused or incorrectly modeled.

  ## Changes

  - Deduplicate card networks when credit and debit card entries are merged.
  - Handle invalid `last_used_at` values safely while sorting saved payment methods.
  - Preserve `mandate_id` as genuinely optional instead of representing absence as an empty string.
  - Remove the unused `should_block_confirm` field.
  - Reuse the parsed client-response dictionary when parsing saved payment methods.
  - Rename the saved-method parser to reflect its purpose and reuse it in the headless flow.
  - Simplify parser type references.
  - Update the shared-code revision required by the SDK-config parser.