### PR TITLE
feat: add hideCardNicknameField prop to hide the card nickname input

### DIFF
--- a/src/components/dynamic/DynamicFields.res
+++ b/src/components/dynamic/DynamicFields.res
@@ -76,22 +76,24 @@ let make = (
         </ReactNative.View>
       | _ => React.null
       }}
-      {switch (
-        clientData->Option.map(data => data.intent_data.is_guest_customer)->Option.getOr(true),
-        isNicknameSelected,
-        nativeProp.configuration.displaySavedPaymentMethodsCheckbox,
-        clientData
-        ->Option.map(data => data.intent_data.payment_type)
-        ->Option.getOr(NORMAL),
-      ) {
-      | (false, _, true, NEW_MANDATE | NORMAL) =>
-        isNicknameSelected
-          ? <NickNameElement nickname setNickname setIsNicknameValid accessible />
-          : React.null
-      | (false, _, false, NEW_MANDATE) | (false, _, _, SETUP_MANDATE) =>
-        <NickNameElement nickname setNickname setIsNicknameValid accessible />
-      | _ => React.null
-      }}
+      <UIUtils.RenderIf condition={!nativeProp.configuration.hideCardNicknameField}>
+        {switch (
+          clientData->Option.map(data => data.intent_data.is_guest_customer)->Option.getOr(true),
+          isNicknameSelected,
+          nativeProp.configuration.displaySavedPaymentMethodsCheckbox,
+          clientData
+          ->Option.map(data => data.intent_data.payment_type)
+          ->Option.getOr(NORMAL),
+        ) {
+        | (false, _, true, NEW_MANDATE | NORMAL) =>
+          isNicknameSelected
+            ? <NickNameElement nickname setNickname setIsNicknameValid accessible />
+            : React.null
+        | (false, _, false, NEW_MANDATE) | (false, _, _, SETUP_MANDATE) =>
+          <NickNameElement nickname setNickname setIsNicknameValid accessible />
+        | _ => React.null
+        }}
+      </UIUtils.RenderIf>
       <Space height=10. />
     </UIUtils.RenderIf>
     <UIUtils.RenderIf

--- a/src/types/SdkTypes.res
+++ b/src/types/SdkTypes.res
@@ -254,6 +254,7 @@ type configurationType = {
   paymentMethodOrder: array<string>,
   paymentMethodLayout: LayoutTypes.layout,
   splitCardFields: bool,
+  hideCardNicknameField: bool,
 }
 
 type sdkState =
@@ -804,6 +805,7 @@ let parseConfigurationDict = (configObj: Dict.t<JSON.t>, displayPayButton) => {
     ->Array.toReversed,
     paymentMethodLayout: LayoutTypes.parseLayout(configObj),
     splitCardFields: getBool(configObj, "splitCardFields", false),
+    hideCardNicknameField: getBool(configObj, "hideCardNicknameField", false),
   }
 }
 


### PR DESCRIPTION
Description:
## What
Adds a `hideCardNicknameField` configuration prop (default `false`). When `true`, the
card nickname input is hidden regardless of every other condition.

## Why
A requirement to suppress the nickname field. Today its visibility is derived entirely
from intent/customer state, and in two of those states it is forced on with no merchant
control:

| Condition | Nickname field |
|---|---|
| `displaySavedPaymentMethodsCheckbox: true` + `NORMAL`/`NEW_MANDATE` | only when "Save card details" is ticked |
| `displaySavedPaymentMethodsCheckbox: false` + `NEW_MANDATE` | **always shown — no escape hatch** |
| `SETUP_MANDATE` (any checkbox setting) | **always shown — no escape hatch** |
| guest customer / non-card / gift card / no dynamic fields | already hidden |

## How
- `SdkTypes.res` — field on `configurationType` + `getBool(configObj, "hideCardNicknameField", false)`
- `DynamicFields.res` — wraps the existing nickname `switch` in `UIUtils.RenderIf`, leaving
  all arms untouched

`RenderIf` returns `React.null`, so `NickNameElement` never mounts. `nickname` stays `None`
and `isNicknameValid` stays `true`, so no guards are needed at the three `nick_name` confirm
sites (`DynamicComponent.res`, `PaymentMethod.res`, `SavedPaymentSheet.res`) or the pay-button
gate (`TabElement.res`) — they are correct by construction.

## Card saving is unaffected
`isNicknameSelected` doubles as save-consent (`PaymentUtils.res:47-54`). Verified
`customer_acceptance` is still sent in all three arms — the card still saves, it just has
no nickname. The "Save card details" checkbox is deliberately untouched, as is the
saved-card nickname *label* in `SavedPaymentMethod.res`.

## Testing
- `yarn re:check` — 714/714 clean
- Default (`false`) → behaviour identical for existing merchants
- `true` + `SETUP_MANDATE` → field gone, pay button still enables, no `nick_name` in confirm body
