### PR TITLE
feat: add separatorText layout prop to customize the wallet separator

### DIFF
--- a/src/pages/payment/WalletView.res
+++ b/src/pages/payment/WalletView.res
@@ -25,6 +25,7 @@ module WalletDisclaimer = {
 @react.component
 let make = (~isLoading=true, ~elementArr, ~showDisclaimer=false, ~hideDivider=false) => {
   let localeObject = GetLocale.useGetLocalObj()
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   <>
     {switch elementArr->Array.length {
     | 0 => React.null
@@ -37,7 +38,12 @@ let make = (~isLoading=true, ~elementArr, ~showDisclaimer=false, ~hideDivider=fa
         </UIUtils.RenderIf>
         <UIUtils.RenderIf condition={!hideDivider}>
           <Space height=15. />
-          <TextWithLine text=localeObject.orPayUsing isLoading />
+          <TextWithLine
+            text={nativeProp.configuration.paymentMethodLayout.separatorText->Option.getOr(
+              localeObject.orPayUsing,
+            )}
+            isLoading
+          />
           <Space height=5. />
         </UIUtils.RenderIf>
       </>

--- a/src/types/LayoutTypes.res
+++ b/src/types/LayoutTypes.res
@@ -30,6 +30,7 @@ type layout = {
   cvcIcon: visibility,
   cardBrandIcon: cardBrandVisibility,
   showCheckedIconForSelection: bool,
+  separatorText: option<string>,
   savedMethodCustomization: savedMethodCustomization,
 }
 
@@ -44,6 +45,7 @@ let defaultLayout: layout = {
   cvcIcon: Shown,
   cardBrandIcon: Standard,
   showCheckedIconForSelection: false,
+  separatorText: None,
   savedMethodCustomization: {
     hideCardExpiry: false,
     hideCVCError: false,
@@ -98,6 +100,7 @@ let parseLayout = (configObj: Dict.t<JSON.t>) => {
         | _ => Animated
         },
         showCheckedIconForSelection: getBool(obj, "showCheckedIconForSelection", false),
+        separatorText: getOptionString(obj, "separatorText"),
         savedMethodCustomization: {
           hideCardExpiry: getBool(savedMethodCustomizationDict, "hideCardExpiry", false),
           hideCVCError: getBool(savedMethodCustomizationDict, "hideCVCError", false),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Chore
- [ ] CI/CD
- [ ] Docs

---


  ## What
  Adds an optional `separatorText` to the `paymentMethodLayout` object. When set, it
  replaces the localized "Or pay using" text on the divider between the wallet buttons
  and the remaining payment methods. When unset, behaviour is unchanged.

  ## Why
  The separator text was locale-only (`localeObject.orPayUsing`) with no merchant
  override. Merchants who want their own wording ("Or continue with", "More ways to
  pay") had no way to set it without shipping a custom locale.

  ## How
  - `LayoutTypes.res` - `separatorText: option<string>` on `type layout`, `None` in
    `defaultLayout`, `getOptionString(obj, "separatorText")` in `parseLayout`
  - `WalletView.res` - reads `nativePropContext` and feeds `TextWithLine` with
    `...paymentMethodLayout.separatorText->Option.getOr(localeObject.orPayUsing)`
  - `DemoAppIndex.js` - sets it in the web demo to exercise the prop

  Same override shape as `primaryButtonLabel` overriding `localeObject.payNowButton`
  in `ConfirmButton.res`.

  ## Web parity
  Identical to hyperswitch-web (`PaymentType.res:172`, `Or.res:4`): same key name,
  same nesting under layout, `option<string>` defaulting to `None`, parsed with
  `getOptionString`, consumed as `->Option.getOr(localeString.orPayUsing)`. Web
  additionally registers the key in an `unknownKeysWarning` list; client-core has no
  such list for layout, so there was nothing to mirror.

  ## Testing
  - `yarn re:check` - 711/711 clean
  - `yarn build:web` - compiles, prop present in the production bundle
  - Verified on the running web demo

  Ran the compiled `parseLayout` against each platform's real payload shape, since
  Android writes strings unconditionally (`putString`) while iOS/web omit absent keys:

  | Payload | set | unset |
  |---|---|---|
  | web (JSON object) | custom text | falls back to locale |
  | iOS (`Encodable` JSON, key omitted) | custom text | falls back to locale |
  | Android (Bundle -> ReadableMap, explicit `null`) | custom text | falls back to locale |

  `getOptionString` is `Dict.get -> Option.flatMap(JSON.Decode.string)`, so both an
  absent key and an explicit `null` decode to `None`.

  ## Notes




---

## Screenshots / Recordings

<!-- Screenshots / Recordings of the change if applicable -->

---

## Affected Area & Impact

<!-- Select all that apply -->

- [x] Client Core
- [ ] Shared Codebase
- [x] Android 
- [x] iOS 

**Android PR / status (if any):**  
**iOS PR / status (if any):**
**Shared Codebase PR / status (if any):**



## Testing

- [x] JS bundle built
- [x] Tested in Android app
- [x] Tested in iOS app

**Notes:**

---

## Checklist

- [ ] Tested in consuming Android app
- [ ] Tested in consuming iOS app
