### PR TITLE
feat: added hyperswitch and vgs vaulting support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,12 @@
   },
   "dependencies": {
     "@juspay-tech/react-native-hyperswitch-netcetera-3ds": "^0.2.2",
+    "@juspay-tech/react-native-hyperswitch-payment-methods": "1.0.0",
     "@juspay-tech/react-native-hyperswitch-paypal": "^1.0.2",
     "@juspay-tech/react-native-hyperswitch-scancard": "^0.2.3",
+    "@juspay-tech/react-native-hyperswitch-vault": "1.0.0",
     "@sentry/react-native": "^8.18.0",
+    "@vgs/collect-react-native": "^1.2.0",
     "base-64": "^1.0.0",
     "final-form": "^5.0.0",
     "react-final-form": "^7.0.0",

--- a/reactNativeWeb/webpack.config.js
+++ b/reactNativeWeb/webpack.config.js
@@ -153,6 +153,9 @@ module.exports = {
       'react-native-plaid-link-sdk': 'react-native-web',
       '@react-native-clipboard/clipboard':
         'react-native-web/dist/exports/Clipboard',
+      '@basis-theory/react-native-elements': false,
+      '@evervault/react-native': false,
+      'skyflow-react-native': false,
     },
   },
   optimization: {

--- a/src/components/dynamic/DynamicComponent.res
+++ b/src/components/dynamic/DynamicComponent.res
@@ -14,6 +14,10 @@ let make = (~setConfirmButtonData) => {
     country,
     setInitialValueCountry,
   } = React.useContext(DynamicFieldsContext.dynamicFieldsContext)
+  let {strategy, getFormState, setShowErrors} = React.useContext(
+    CardStrategyContext.cardStrategyContext,
+  )
+  let submitVaultCard = VaultCardSubmitHook.useVaultCardSubmit()
 
   let {
     missingRequiredFields,
@@ -28,6 +32,7 @@ let make = (~setConfirmButtonData) => {
   } = walletData
   let payment_method = paymentMethodData.payment_method
   let payment_method_str = paymentMethodData.payment_method_str
+  let vaultFormId = "sheet-" ++ paymentMethodData.payment_method_type
   let payment_method_type = paymentMethodData.payment_method_type
   let payment_method_type_wallet = paymentMethodData.payment_method_type_wallet
   let payment_experience = paymentMethodData.payment_experience
@@ -105,23 +110,7 @@ let make = (~setConfirmButtonData) => {
 
     let paymentMethodDataDict = switch payment_method {
     | CARD =>
-      switch nickname {
-      | Some(name) =>
-        [
-          (
-            "payment_method_data",
-            [
-              (
-                payment_method_str,
-                [("nick_name", name->Js.Json.string)]->Dict.fromArray->Js.Json.object_,
-              ),
-            ]
-            ->Dict.fromArray
-            ->Js.Json.object_,
-          ),
-        ]->Dict.fromArray
-      | None => Dict.make()
-      }
+      PaymentUtils.nicknamePaymentMethodData(~tabDict, ~paymentMethodStr=payment_method_str, ~nickname)
     | pm =>
       [
         (
@@ -151,6 +140,8 @@ let make = (~setConfirmButtonData) => {
       ~nativeProp,
       ~payment_method_str,
       ~payment_method_type,
+      ~payment_token=?tabDict->Dict.get("payment_token")->Option.flatMap(JSON.Decode.string),
+      ~isVaultedNewCard=PaymentUtils.isVaultedNewCard(tabDict),
       ~payment_method_data=?CommonUtils.mergeDict(paymentMethodDataDict, tabDict)->Dict.get(
         "payment_method_data",
       ),
@@ -189,30 +180,60 @@ let make = (~setConfirmButtonData) => {
     )->ignore
   }
 
+  let isVaultCard = switch (payment_method, strategy) {
+  | (CARD, CardStrategyContext.VaultCard(_)) => true
+  | _ => false
+  }
+
   let handlePress = _ => {
-    if isFormValid || missingRequiredFields->Array.length === 0 {
-      processRequest(
-        CommonUtils.mergeDict(initialValues, formData),
-        Some(walletDict),
-        formData->Dict.get("email")->Option.mapOr(None, JSON.Decode.string),
-      )
-    } else {
-      switch formMethods {
-      | Some(methods) => methods.submit()
-      | None => ()
+    switch (payment_method, strategy) {
+    | (CARD, CardStrategyContext.Pending)
+    | (CARD, CardStrategyContext.Refused(_)) => ()
+    | (CARD, CardStrategyContext.VaultCard(_)) =>
+      if isFormValid {
+        submitVaultCard(~formId=vaultFormId, ~shape=WholeCard, ~onTokenized=vaultPmd =>
+          processRequest(
+            CommonUtils.mergeDict(CommonUtils.mergeDict(initialValues, formData), vaultPmd),
+            Some(walletDict),
+            formData->Dict.get("email")->Option.mapOr(None, JSON.Decode.string),
+          )
+        )
+      } else {
+        switch formMethods {
+        | Some(methods) => methods.submit()
+        | None => ()
+        }
+        setShowErrors(vaultFormId, true)
+        notifyValidationFailure()
       }
-      notifyValidationFailure()
+    | _ =>
+      if isFormValid || missingRequiredFields->Array.length === 0 {
+        processRequest(
+          CommonUtils.mergeDict(initialValues, formData),
+          Some(walletDict),
+          formData->Dict.get("email")->Option.mapOr(None, JSON.Decode.string),
+        )
+      } else {
+        switch formMethods {
+        | Some(methods) => methods.submit()
+        | None => ()
+        }
+        notifyValidationFailure()
+      }
     }
   }
+
+  let effectiveFormValid =
+    isVaultCard ? getFormState(vaultFormId).isValid && isFormValid : isFormValid
 
   FormStatusEmitter.useFormStatusEmitter(
     ~isFocused=true,
     ~hasRequiredFields=missingRequiredFields->Array.length > 0,
-    ~isFormValid,
+    ~isFormValid=effectiveFormValid,
     ~isPristine,
   )
 
-  React.useEffect3(() => {
+  React.useEffect4(() => {
     let confirmButton = {
       GlobalConfirmButton.loading: false,
       handlePress,
@@ -223,7 +244,7 @@ let make = (~setConfirmButtonData) => {
     setConfirmButtonData(confirmButton)
 
     None
-  }, (walletData, isFormValid, formData))
+  }, (walletData, effectiveFormValid, formData, strategy))
 
   <ReactNative.View
     style={ReactNative.Style.s({paddingVertical: sheetContentPadding->ReactNative.Style.dp})}>
@@ -238,6 +259,7 @@ let make = (~setConfirmButtonData) => {
       isCardPayment
       enabledCardSchemes
       accessible=true
+      vaultFormId
     />
   </ReactNative.View>
 }

--- a/src/components/dynamic/DynamicFields.res
+++ b/src/components/dynamic/DynamicFields.res
@@ -13,6 +13,7 @@ let make = (
   ~isFocused: bool=false,
   ~checkEligibility: option<string> => unit=_ => (),
   ~customerAcceptanceSupport: option<PaymentMethodType.customerAcceptanceSupport>=?,
+  ~vaultFormId: string="",
 ) => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
   let (clientData, _, _) = React.useContext(
@@ -91,6 +92,7 @@ let make = (
         accessible
         isFocused
         checkEligibility
+        vaultFormId
       />
     </UIUtils.RenderIf>
     <UIUtils.RenderIf condition={isCardPayment && !isGiftCardPayment && fields->Array.length > 0}>

--- a/src/components/dynamic/ParentElement.res
+++ b/src/components/dynamic/ParentElement.res
@@ -16,12 +16,22 @@ let make = (
   ~enabledCardSchemes: array<string>=[],
   ~accessible=?,
   ~checkEligibility: option<string> => unit=_ => (),
+  ~vaultFormId: string="",
 ) => {
+  let {strategy} = React.useContext(CardStrategyContext.cardStrategyContext)
+
   switch element {
   | CARD(fields) if fields->Array.length > 0 =>
-    <CardElement
-      fields createFieldValidator formatValue enabledCardSchemes ?accessible checkEligibility
-    />
+    switch strategy {
+    | DirectCard =>
+      <CardElement
+        fields createFieldValidator formatValue enabledCardSchemes ?accessible checkEligibility
+      />
+    | VaultCard(vaultDetails) =>
+      <VaultCardElement fields vaultDetails formId=vaultFormId enabledCardSchemes ?accessible />
+    | Pending => React.null
+    | Refused(_) => <ErrorText text=PaymentConfirmTypes.defaultConfigError.message />
+    }
   | CRYPTO(fields) if fields->Array.length > 0 =>
     <CryptoElement fields createFieldValidator formatValue ?accessible />
   | EMAIL(fields) if fields->Array.length > 0 =>

--- a/src/components/dynamic/RequiredFields.res
+++ b/src/components/dynamic/RequiredFields.res
@@ -14,6 +14,7 @@ let make = (
   ~onSubmit=?,
   ~isFocused: bool=false,
   ~checkEligibility: option<string> => unit=_ => (),
+  ~vaultFormId: string="",
 ) => {
   let groups = React.useMemo1(() => FieldGrouper.groupFields(fields), [fields])
 
@@ -58,6 +59,7 @@ let make = (
             enabledCardSchemes
             ?accessible
             checkEligibility
+            vaultFormId
           />
         )
         ->React.array}

--- a/src/components/dynamic/TabElement.res
+++ b/src/components/dynamic/TabElement.res
@@ -15,6 +15,12 @@ let make = (
     eligibilityStatus,
     isSaveDetailsSelected,
   } = React.useContext(DynamicFieldsContext.dynamicFieldsContext)
+  let {strategy, getFormState, setShowErrors} = React.useContext(
+    CardStrategyContext.cardStrategyContext,
+  )
+  let submitVaultCard = VaultCardSubmitHook.useVaultCardSubmit()
+
+  let vaultFormId = "tab-" ++ paymentMethodData.payment_method_type
 
   let (formData, setFormData) = React.useState(_ => Dict.make())
   let setFormData = React.useCallback1(data => {
@@ -50,23 +56,52 @@ let make = (
     getRequiredFieldsForTabs(paymentMethodData, formData, isScreenFocus)
   }, (paymentMethodData.payment_method_type, getRequiredFieldsForTabs, country, isScreenFocus))
 
+  let isVaultCard = switch (paymentMethodData.payment_method, strategy) {
+  | (CARD, CardStrategyContext.VaultCard(_)) => true
+  | _ => false
+  }
+
   let handlePress = _ => {
     // Only gate on eligibility for card payments; non-card methods skip the check
     let isEligibilityBlocked = isCardPayment && eligibilityStatus !== DynamicFieldsContext.Allowed
     if isEligibilityBlocked {
       ()
-    } else if isNicknameValid && (isFormValid || requiredFields->Array.length === 0) {
-      processRequest(
-        CommonUtils.mergeDict(initialValues, formData),
-        None,
-        formData->Dict.get("email")->Option.mapOr(None, JSON.Decode.string),
-      )
     } else {
-      switch formMethods {
-      | Some(methods: ReactFinalForm.Form.formMethods) => methods.submit()
-      | None => ()
+      switch (paymentMethodData.payment_method, strategy) {
+      | (CARD, CardStrategyContext.Pending)
+      | (CARD, CardStrategyContext.Refused(_)) => ()
+      | (CARD, CardStrategyContext.VaultCard(_)) =>
+        if isNicknameValid && isFormValid {
+          submitVaultCard(~formId=vaultFormId, ~shape=WholeCard, ~onTokenized=vaultPmd =>
+            processRequest(
+              CommonUtils.mergeDict(CommonUtils.mergeDict(initialValues, formData), vaultPmd),
+              None,
+              formData->Dict.get("email")->Option.mapOr(None, JSON.Decode.string),
+            )
+          )
+        } else {
+          switch formMethods {
+          | Some(methods: ReactFinalForm.Form.formMethods) => methods.submit()
+          | None => ()
+          }
+          setShowErrors(vaultFormId, true)
+          notifyValidationFailure()
+        }
+      | _ =>
+        if isNicknameValid && (isFormValid || requiredFields->Array.length === 0) {
+          processRequest(
+            CommonUtils.mergeDict(initialValues, formData),
+            None,
+            formData->Dict.get("email")->Option.mapOr(None, JSON.Decode.string),
+          )
+        } else {
+          switch formMethods {
+          | Some(methods: ReactFinalForm.Form.formMethods) => methods.submit()
+          | None => ()
+          }
+          notifyValidationFailure()
+        }
       }
-      notifyValidationFailure()
     }
   }
 
@@ -75,10 +110,13 @@ let make = (
     None
   }, [defaultCountry])
 
+  let effectiveFormValid =
+    isVaultCard ? getFormState(vaultFormId).isValid && isNicknameValid && isFormValid : isFormValid
+
   FormStatusEmitter.useFormStatusEmitter(
     ~isFocused=isScreenFocus,
     ~hasRequiredFields=requiredFields->Array.length > 0,
-    ~isFormValid,
+    ~isFormValid=effectiveFormValid,
     ~isPristine,
   )
 
@@ -102,11 +140,12 @@ let make = (
     setConfirmButtonData,
     eligibilityStatus,
     requiredFields,
-    isFormValid,
+    effectiveFormValid,
     formData,
     formMethods,
     isNicknameValid,
     isSaveDetailsSelected,
+    strategy,
   ))
 
   <DynamicFields
@@ -122,5 +161,6 @@ let make = (
     isFocused=isScreenFocus
     checkEligibility
     customerAcceptanceSupport=?paymentMethodData.customer_acceptance_support
+    vaultFormId
   />
 }

--- a/src/components/vault/VaultBindings.res
+++ b/src/components/vault/VaultBindings.res
@@ -1,0 +1,139 @@
+type fieldStyles = {
+  container?: ReactNative.Style.t,
+  input?: ReactNative.Style.t,
+}
+
+type fieldHandle = {focus: unit => unit, blur: unit => unit, clear: unit => unit}
+type fieldRef = React.ref<Nullable.t<fieldHandle>>
+let focusField = (reference: fieldRef) => reference.current->Nullable.toOption->Option.forEach(handle => handle.focus())
+
+type fieldEvent = {elementType: string}
+
+type fieldChange = {
+  elementType: string,
+  empty: bool,
+  complete: bool,
+  valid: bool,
+  brand?: string,
+  error?: string,
+  touched: bool,
+}
+
+type savedCardData = {cardNetwork?: string}
+type savedCardPaymentMethodData = {card?: savedCardData}
+
+type savedCard = {
+  paymentMethodToken?: string,
+  paymentMethodData?: savedCardPaymentMethodData,
+}
+
+type fieldOptions = {savedCard?: savedCard}
+
+type cardFormEvent = {elementType: string}
+
+type cardDetails = {
+  bin: Nullable.t<string>,
+  last4: Nullable.t<string>,
+  brand: Nullable.t<string>,
+  expiryMonth: Nullable.t<string>,
+  expiryYear: Nullable.t<string>,
+  formattedExpiry: Nullable.t<string>,
+  isCardNumberComplete: bool,
+  isCvcComplete: bool,
+  isExpiryComplete: bool,
+  isCardNumberValid: bool,
+  isExpiryValid: bool,
+}
+
+type cardFormChange = {
+  elementType: string,
+  eventName: string,
+  payload: cardDetails,
+  complete: bool,
+  valid: bool,
+  fields: Dict.t<fieldChange>,
+}
+
+type tokenizeError = {
+  code: string,
+  message: string,
+  @as("type") type_: string,
+}
+
+type tokenizeData = {tokens?: Dict.t<JSON.t>}
+
+type tokenizeResult = {
+  status: string,
+  vaultType?: string,
+  data?: tokenizeData,
+  error?: tokenizeError,
+}
+
+module CardForm = {
+  @module("@juspay-tech/react-native-hyperswitch-payment-methods") @react.component
+  external make: (
+    ~id: string=?,
+    ~vaultDetails: JSON.t=?,
+    ~onReady: cardFormEvent => unit=?,
+    ~onChange: cardFormChange => unit=?,
+    ~onError: JSON.t => unit=?,
+    ~children: React.element,
+  ) => React.element = "CardForm"
+}
+
+module CardNumberField = {
+  @module("@juspay-tech/react-native-hyperswitch-payment-methods") @react.component
+  external make: (
+    ~ref: fieldRef=?,
+    ~unstyled: bool=?,
+    ~onReady: fieldEvent => unit=?,
+    ~styles: fieldStyles=?,
+    ~placeholder: string=?,
+    ~testID: string=?,
+    ~onChange: fieldChange => unit=?,
+    ~onFocus: fieldEvent => unit=?,
+    ~onBlur: fieldEvent => unit=?,
+  ) => React.element = "CardNumberField"
+}
+
+module CardExpiryField = {
+  @module("@juspay-tech/react-native-hyperswitch-payment-methods") @react.component
+  external make: (
+    ~ref: fieldRef=?,
+    ~unstyled: bool=?,
+    ~onReady: fieldEvent => unit=?,
+    ~styles: fieldStyles=?,
+    ~placeholder: string=?,
+    ~testID: string=?,
+    ~onChange: fieldChange => unit=?,
+    ~onFocus: fieldEvent => unit=?,
+    ~onBlur: fieldEvent => unit=?,
+  ) => React.element = "CardExpiryField"
+}
+
+module CardCVCField = {
+  @module("@juspay-tech/react-native-hyperswitch-payment-methods") @react.component
+  external make: (
+    ~ref: fieldRef=?,
+    ~unstyled: bool=?,
+    ~onReady: fieldEvent => unit=?,
+    ~styles: fieldStyles=?,
+    ~placeholder: string=?,
+    ~testID: string=?,
+    ~options: fieldOptions=?,
+    ~onChange: fieldChange => unit=?,
+    ~onFocus: fieldEvent => unit=?,
+    ~onBlur: fieldEvent => unit=?,
+  ) => React.element = "CardCVCField"
+}
+
+type hyperswitchPaymentMethods
+
+@module("@juspay-tech/react-native-hyperswitch-payment-methods")
+external hyperswitchPaymentMethods: hyperswitchPaymentMethods = "HyperswitchPaymentMethods"
+
+@send
+external tokenize: (hyperswitchPaymentMethods, string) => promise<tokenizeResult> = "tokenize"
+
+let tokenizeForm = (formId: string): promise<tokenizeResult> =>
+  hyperswitchPaymentMethods->tokenize(formId)

--- a/src/components/vault/VaultCardElement.res
+++ b/src/components/vault/VaultCardElement.res
@@ -1,0 +1,385 @@
+open ReactNative
+open Style
+
+type focusState = {active: bool, blurred: bool}
+let untouched = {active: false, blurred: false}
+
+type problem = Empty | Invalid
+
+@react.component
+let make = (
+  ~fields: array<SuperpositionTypes.fieldConfig>,
+  ~vaultDetails: VaultDetailsType.vaultDetails,
+  ~formId: string,
+  ~enabledCardSchemes: array<string>=[],
+  ~accessible=?,
+) => {
+  let {getFormState, setFormValid} = React.useContext(CardStrategyContext.cardStrategyContext)
+  let {eligibilityStatus} = React.useContext(DynamicFieldsContext.dynamicFieldsContext)
+  let emitter = PaymentEvents.usePaymentEventEmitter()
+  let {showErrors} = getFormState(formId)
+
+  let numberRef = React.useRef(Nullable.null)
+  let expiryRef = React.useRef(Nullable.null)
+  let cvcRef = React.useRef(Nullable.null)
+  let completedRef = React.useRef(Dict.make())
+  let (mountError, setMountError) = React.useState(() => None)
+  let (formFields, setFormFields) = React.useState(() => Dict.make())
+  let (focusStates, setFocusStates) = React.useState(() => Dict.make())
+  let (expiryFullyTyped, setExpiryFullyTyped) = React.useState(() => false)
+
+  let {
+    component,
+    bgColor,
+    borderWidth,
+    borderRadius,
+    gap,
+    inputHeight,
+    primaryColor,
+    errorTextInputColor,
+    normalTextInputBoderColor,
+    shadowConfig,
+  } = ThemebasedStyle.useThemeBasedStyle()
+  let localeObject = GetLocale.useGetLocalObj()
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+  let splitCardFields = nativeProp.configuration.splitCardFields
+  let shadowStyle = ShadowHook.useGetShadowStyle(~shadowConfig, ())
+
+  let hasCvc =
+    fields
+    ->Array.find((f: SuperpositionTypes.fieldConfig) =>
+      f.fieldRenderType === SuperpositionTypes.Cvc
+    )
+    ->Option.isSome
+
+  let vaultDetailsProp = React.useMemo2(
+    () =>
+      VaultDetailsType.toCardFormProp(
+        vaultDetails,
+        ~environment=nativeProp.hyperswitchConfig.environment,
+      ),
+    (vaultDetails, nativeProp.hyperswitchConfig.environment),
+  )
+
+  let onFormChange = (event: VaultBindings.cardFormChange) => {
+    setFormValid(formId, event.complete && event.valid)
+    setFormFields(_ => event.fields)
+    let p = event.payload
+    setExpiryFullyTyped(_ =>
+      p.expiryMonth->Nullable.toOption->Option.isSome &&
+        p.expiryYear->Nullable.toOption->Option.isSome
+    )
+    let info: PaymentEvents.cardInfo = {
+      bin: p.bin->Nullable.toOption,
+      last4: p.last4->Nullable.toOption,
+      brand: p.brand->Nullable.toOption,
+      expiryMonth: p.expiryMonth->Nullable.toOption,
+      expiryYear: p.expiryYear->Nullable.toOption,
+      formattedExpiry: p.formattedExpiry->Nullable.toOption,
+      isCardNumberComplete: p.isCardNumberComplete,
+      isCvcComplete: p.isCvcComplete,
+      isExpiryComplete: p.isExpiryComplete,
+      isCardNumberValid: p.isCardNumberValid,
+      isExpiryValid: p.isExpiryValid,
+    }
+    emitter.emitCardInfo(~info)
+  }
+
+  let onFormError = (error: JSON.t) => {
+    setFormValid(formId, false)
+    let msg =
+      error
+      ->JSON.Decode.object
+      ->Option.flatMap(o => o->Dict.get("message"))
+      ->Option.flatMap(JSON.Decode.string)
+      ->Utils.getNonEmptyOption
+      ->Option.getOr(VaultTokenNormalizer.fallbackMessage)
+    setMountError(_ => Some(msg))
+  }
+
+  let setFocus = (elementType, active) =>
+    setFocusStates(prev => {
+      let current = prev->Dict.get(elementType)->Option.getOr(untouched)
+      let copy = prev->Dict.copy
+      copy->Dict.set(
+        elementType,
+        {active, blurred: current.blurred || (!active && current.active)},
+      )
+      copy
+    })
+  let onFieldFocus = (event: VaultBindings.fieldEvent) => setFocus(event.elementType, true)
+  let onFieldBlur = (event: VaultBindings.fieldEvent) => setFocus(event.elementType, false)
+
+  React.useEffect0(() => {
+    Some(() => setFormValid(formId, false))
+  })
+
+  let focusOf = elementType => focusStates->Dict.get(elementType)->Option.getOr(untouched)
+  let isActive = elementType => focusOf(elementType).active
+  let isTouched = elementType => focusOf(elementType).blurred || showErrors
+  let problemOf = elementType =>
+    switch formFields->Dict.get(elementType) {
+    | Some(change) if change.empty => Some(Empty)
+    | Some(change) if !change.valid => Some(Invalid)
+    | Some(_) => None
+    | None => Some(Empty)
+    }
+  let expiryInvalidComplete = expiryFullyTyped && problemOf("cardExpiry") === Some(Invalid)
+  let looksValid = elementType =>
+    problemOf(elementType)->Option.isNone ||
+      ((!isTouched(elementType) || isActive(elementType)) &&
+        !(elementType === "cardExpiry" && expiryInvalidComplete))
+
+  let numberMessage = switch problemOf("cardNumber") {
+  | Some(Empty) if isTouched("cardNumber") => Some(localeObject.cardNumberEmptyText)
+  | Some(Invalid) if isTouched("cardNumber") => Some(localeObject.inValidCardErrorText)
+  | _ => None
+  }
+  let expiryMessage = switch problemOf("cardExpiry") {
+  | Some(Empty) if isTouched("cardExpiry") => Some(localeObject.cardExpiryDateEmptyText)
+  | Some(Invalid) if (isTouched("cardExpiry") && !isActive("cardExpiry")) || expiryInvalidComplete =>
+    Some(localeObject.inValidExpiryErrorText)
+  | _ => None
+  }
+  let cvcMessage = switch problemOf("cardCvc") {
+  | Some(Empty) if hasCvc && isTouched("cardCvc") && !isActive("cardCvc") =>
+    Some(localeObject.cvcNumberEmptyText)
+  | Some(Invalid) if hasCvc && isTouched("cardCvc") && !isActive("cardCvc") =>
+    Some(localeObject.inValidCVCErrorText)
+  | _ => None
+  }
+  let detectedBrand =
+    formFields->Dict.get("cardNumber")->Option.flatMap(change => change.brand)->Option.getOr("")
+  let networkMessage =
+    showErrors &&
+    detectedBrand !== "" &&
+    enabledCardSchemes->Array.length > 0 &&
+    enabledCardSchemes
+    ->Array.find(scheme => scheme->String.toLowerCase === detectedBrand->String.toLowerCase)
+    ->Option.isNone
+      ? Some(localeObject.unsupportedCardErrorText)
+      : None
+  let eligibilityMessage = switch eligibilityStatus {
+  | DynamicFieldsContext.Denied => Some(localeObject.cardNotEligibleText)
+  | _ => None
+  }
+  let firstSome = messages =>
+    messages->Array.reduce(None, (acc, m) => acc->Option.isSome ? acc : m)
+
+  let fieldBox = (
+    ~elementType,
+    ~borderTopWidth=?,
+    ~borderBottomWidth=?,
+    ~borderLeftWidth=?,
+    ~borderRightWidth=?,
+    ~borderTopLeftRadius=?,
+    ~borderTopRightRadius=?,
+    ~borderBottomLeftRadius=?,
+    ~borderBottomRightRadius=?,
+    (),
+  ) =>
+    array([
+      bgColor,
+      s({
+        backgroundColor: component.background,
+        borderTopWidth: borderTopWidth->Option.getOr(borderWidth),
+        borderBottomWidth: borderBottomWidth->Option.getOr(borderWidth),
+        borderLeftWidth: borderLeftWidth->Option.getOr(borderWidth),
+        borderRightWidth: borderRightWidth->Option.getOr(borderWidth),
+        borderTopLeftRadius: borderTopLeftRadius->Option.getOr(borderRadius),
+        borderTopRightRadius: borderTopRightRadius->Option.getOr(borderRadius),
+        borderBottomLeftRadius: borderBottomLeftRadius->Option.getOr(borderRadius),
+        borderBottomRightRadius: borderBottomRightRadius->Option.getOr(borderRadius),
+        height: inputHeight->dp,
+        flexDirection: #row,
+        borderColor: looksValid(elementType)
+          ? isActive(elementType) ? primaryColor : normalTextInputBoderColor
+          : errorTextInputColor,
+        width: 100.->pct,
+        paddingHorizontal: 13.->dp,
+        alignItems: #center,
+        justifyContent: #center,
+      }),
+      shadowStyle,
+    ])
+
+  let emptyOf = kind => formFields->Dict.get(kind)->Option.mapOr(true, field => field.empty)
+  let completeOf = kind => formFields->Dict.get(kind)->Option.mapOr(false, field => field.complete)
+  let advanceFocus = (event: VaultBindings.fieldChange) => {
+    let wasComplete = completedRef.current->Dict.get(event.elementType)->Option.getOr(false)
+    completedRef.current->Dict.set(event.elementType, event.complete)
+    if event.complete && !wasComplete && isActive(event.elementType) {
+      switch event.elementType {
+      | "cardNumber" => VaultBindings.focusField(expiryRef)
+      | "cardExpiry" if hasCvc => VaultBindings.focusField(cvcRef)
+      | _ => ()
+      }
+    }
+  }
+
+  let errorLine = messages => <ErrorText text={firstSome(messages)} />
+
+  let isVgs = switch vaultDetails.config {
+  | VaultDetailsType.VgsVault(_) => true
+  | VaultDetailsType.HyperswitchVault(_) => false
+  }
+  let brandIconFromProvider =
+    isVgs && nativeProp.configuration.paymentMethodLayout.cardBrandIcon !== Hidden
+  let cvcIconFromProvider =
+    isVgs && nativeProp.configuration.paymentMethodLayout.cvcIcon === Shown
+
+  let cardBrandIcon = isVgs
+    ? None
+    : Some(
+        <CardSchemeComponent
+          eligibleCardSchemes=[]
+          showCardSchemeDropDown=false
+          cardBrand=detectedBrand
+          setCardBrand={_ => ()}
+          cardBrandIcon=nativeProp.configuration.paymentMethodLayout.cardBrandIcon
+        />,
+      )
+  let cvcIcon =
+    !isVgs && nativeProp.configuration.paymentMethodLayout.cvcIcon === Shown
+      ? Some(
+          <View
+            style={s({
+              height: 46.->dp,
+              display: #flex,
+              flexDirection: #row,
+              justifyContent: #center,
+              alignItems: #center,
+            })}>
+            <Icon
+              name="cvv" height=32. width=32. fill={completeOf("cardCvc") ? primaryColor : "#858F97"}
+            />
+          </View>,
+        )
+      : None
+
+  <View ?accessible>
+    <VaultBindings.CardForm
+      id=formId vaultDetails=vaultDetailsProp onChange=onFormChange onError=onFormError>
+      <View style={s({marginBottom: gap->dp})}>
+        <View style={s({width: 100.->pct, borderRadius})}>
+          <View
+            style={s({
+              width: 100.->pct,
+              marginBottom: ?(splitCardFields ? Some(gap->dp) : None),
+            })}>
+            <View
+              style={fieldBox(
+                ~elementType="cardNumber",
+                ~borderBottomWidth=?{splitCardFields ? None : Some(borderWidth /. 2.)},
+                ~borderBottomLeftRadius=?{splitCardFields ? None : Some(0.)},
+                ~borderBottomRightRadius=?{splitCardFields ? None : Some(0.)},
+                (),
+              )}>
+              <VaultInput
+                  elementType="cardNumber"
+                  height=inputHeight
+                  reference=numberRef
+                  label=localeObject.cardNumberLabel
+                  active={isActive("cardNumber")}
+                  empty={emptyOf("cardNumber")}
+                  valid={looksValid("cardNumber")}
+                  iconRight=?cardBrandIcon
+                  useProviderIcon=brandIconFromProvider
+                  onChange=advanceFocus
+                testID=TestUtils.cardNumberInputTestId
+                placeholder={nativeProp.configuration.placeholder.cardNumber->Option.getOr(
+                  localeObject.cardNumberLabel,
+                )}
+                onFocus=onFieldFocus
+                onBlur=onFieldBlur
+              />
+            </View>
+            <UIUtils.RenderIf condition={splitCardFields}> {errorLine([numberMessage])} </UIUtils.RenderIf>
+          </View>
+          <View
+            style={s({
+              flexDirection: localeObject.localeDirection === "rtl" ? #"row-reverse" : #row,
+              gap: ?(splitCardFields ? Some(gap->dp) : None),
+            })}>
+            <View style={s({flex: 1.})}>
+              <View
+                style={fieldBox(
+                  ~elementType="cardExpiry",
+                  ~borderTopWidth=?{splitCardFields ? None : Some(borderWidth /. 2.)},
+                  ~borderRightWidth=?{splitCardFields
+                    ? None
+                    : Some(hasCvc ? borderWidth /. 2. : borderWidth)},
+                  ~borderTopLeftRadius=?{splitCardFields ? None : Some(0.)},
+                  ~borderTopRightRadius=?{splitCardFields ? None : Some(0.)},
+                  ~borderBottomRightRadius=?{splitCardFields
+                    ? None
+                    : Some(hasCvc ? 0. : borderRadius)},
+                  (),
+                )}>
+                <VaultInput
+                  elementType="cardExpiry"
+                  height=inputHeight
+                  reference=expiryRef
+                  label=localeObject.validThruText
+                  active={isActive("cardExpiry")}
+                  empty={emptyOf("cardExpiry")}
+                  valid={looksValid("cardExpiry")}
+                  onChange=advanceFocus
+                    testID=TestUtils.expiryInputTestId
+                  placeholder={nativeProp.configuration.placeholder.expiryDate->Option.getOr(
+                    localeObject.validThruText,
+                  )}
+                  onFocus=onFieldFocus
+                  onBlur=onFieldBlur
+                />
+              </View>
+              <UIUtils.RenderIf condition={splitCardFields}>
+                {errorLine([expiryMessage])}
+              </UIUtils.RenderIf>
+            </View>
+            <UIUtils.RenderIf condition={hasCvc}>
+              <View style={s({flex: 1.})}>
+                <View
+                  style={fieldBox(
+                    ~elementType="cardCvc",
+                    ~borderTopWidth={splitCardFields ? borderWidth : borderWidth /. 2.},
+                    ~borderLeftWidth={splitCardFields ? borderWidth : borderWidth /. 2.},
+                    ~borderTopLeftRadius={splitCardFields ? borderRadius : 0.},
+                    ~borderTopRightRadius={splitCardFields ? borderRadius : 0.},
+                    ~borderBottomLeftRadius={splitCardFields ? borderRadius : 0.},
+                    (),
+                  )}>
+                  <VaultInput
+                  elementType="cardCvc"
+                  height=inputHeight
+                  reference=cvcRef
+                  label=localeObject.cvcTextLabel
+                  active={isActive("cardCvc")}
+                  empty={emptyOf("cardCvc")}
+                  valid={looksValid("cardCvc")}
+                  iconRight=?cvcIcon
+                  useProviderIcon=cvcIconFromProvider
+                  onChange=advanceFocus
+                        testID=TestUtils.cvcInputTestId
+                    placeholder={nativeProp.configuration.placeholder.cvv->Option.getOr(
+                      localeObject.cvcTextLabel,
+                    )}
+                    onFocus=onFieldFocus
+                    onBlur=onFieldBlur
+                  />
+                </View>
+                <UIUtils.RenderIf condition={splitCardFields}>
+                  {errorLine([cvcMessage, networkMessage, eligibilityMessage])}
+                </UIUtils.RenderIf>
+              </View>
+            </UIUtils.RenderIf>
+          </View>
+        </View>
+        <UIUtils.RenderIf condition={!splitCardFields}>
+          {errorLine([numberMessage, expiryMessage, cvcMessage, networkMessage, eligibilityMessage])}
+        </UIUtils.RenderIf>
+      </View>
+    </VaultBindings.CardForm>
+    <ErrorText text={mountError} />
+  </View>
+}

--- a/src/components/vault/VaultCvcElement.res
+++ b/src/components/vault/VaultCvcElement.res
@@ -1,0 +1,184 @@
+open ReactNative
+open Style
+
+let formIdFor = (token: ClientResponseType.customerPaymentMethod) =>
+  "saved-" ++ token.payment_method_id
+
+@react.component
+let make = (
+  ~savedPaymentMethod: ClientResponseType.customerPaymentMethod,
+  ~vaultDetails: VaultDetailsType.vaultDetails,
+  ~hideCardExpiry,
+  ~hideCVCError,
+  ~hideCvcIcon,
+  ~placeholderCVC,
+) => {
+  let formId = formIdFor(savedPaymentMethod)
+  let {getFormState, setFormValid} = React.useContext(CardStrategyContext.cardStrategyContext)
+  let {showErrors} = getFormState(formId)
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
+  let localeObject = GetLocale.useGetLocalObj()
+  let {
+    component,
+    bgColor,
+    borderWidth,
+    borderRadius,
+    inputHeight,
+    primaryColor,
+    errorTextInputColor,
+    normalTextInputBoderColor,
+    shadowConfig,
+  } = ThemebasedStyle.useThemeBasedStyle()
+  let shadowStyle = ShadowHook.useGetShadowStyle(~shadowConfig, ())
+
+  let cvcRef = React.useRef(Nullable.null)
+  let (cvcState, setCvcState) = React.useState(() => None)
+  let (isCvcFocus, setIsCvcFocus) = React.useState(_ => false)
+  let (hasBlurred, setHasBlurred) = React.useState(_ => false)
+  let (mountError, setMountError) = React.useState(() => None)
+
+  let vaultDetailsProp = React.useMemo2(
+    () =>
+      VaultDetailsType.toCardFormProp(
+        vaultDetails,
+        ~environment=nativeProp.hyperswitchConfig.environment,
+      ),
+    (vaultDetails, nativeProp.hyperswitchConfig.environment),
+  )
+
+  let isHyperswitchVault = switch vaultDetails.config {
+  | VaultDetailsType.HyperswitchVault(_) => true
+  | VaultDetailsType.VgsVault(_) => false
+  }
+  let useProviderIcon = !isHyperswitchVault && !hideCvcIcon
+  let boxWidth = hideCvcIcon ? 72. : useProviderIcon ? 128. : 100.
+  let savedCardToken = isHyperswitchVault ? None : Some(savedPaymentMethod.payment_token)
+
+  let savedCard: VaultBindings.fieldOptions = {
+    savedCard: {
+      paymentMethodToken: ?savedCardToken,
+      paymentMethodData: {
+        card: {
+          cardNetwork: ?savedPaymentMethod.card
+          ->Option.map(card => card.card_network)
+          ->Utils.getNonEmptyOption,
+        },
+      },
+    },
+  }
+
+  let onFormChange = (event: VaultBindings.cardFormChange) => {
+    setFormValid(formId, event.complete && event.valid)
+    setCvcState(_ => event.fields->Dict.get("cardCvc"))
+  }
+
+  let onFormError = (error: JSON.t) => {
+    setFormValid(formId, false)
+    let msg =
+      error
+      ->JSON.Decode.object
+      ->Option.flatMap(o => o->Dict.get("message"))
+      ->Option.flatMap(JSON.Decode.string)
+      ->Utils.getNonEmptyOption
+      ->Option.getOr(VaultTokenNormalizer.fallbackMessage)
+    setMountError(_ => Some(msg))
+  }
+
+  React.useEffect0(() => {
+    Some(() => setFormValid(formId, false))
+  })
+
+  let touched = hasBlurred || showErrors
+  let isCvcValid =
+    isCvcFocus || !touched
+      ? true
+      : switch cvcState {
+        | Some(change) => !change.empty && change.valid
+        | None => false
+        }
+  let errorMsgText = !isCvcValid ? Some(localeObject.inCompleteCVCErrorText) : None
+
+  <View
+    style={s({
+      display: #flex,
+      flexDirection: #column,
+      alignItems: hideCardExpiry ? #"flex-end" : #"flex-start",
+      marginHorizontal: hideCardExpiry ? 7.5->dp : 47.5->dp,
+    })}>
+    <View
+      style={s({
+        flex: 1.,
+        display: #flex,
+        flexDirection: #row,
+        alignItems: #center,
+        width: ?(hideCardExpiry ? None : Some(100.->pct)),
+        marginTop: hideCardExpiry
+          ? (errorMsgText->Option.isSome && !hideCVCError ? 2. : 0.)->dp
+          : 10.->dp,
+      })}>
+      {hideCardExpiry
+        ? React.null
+        : <View style={s({width: {50.->dp}})}>
+            <TextWrapper text="CVC:" textType={ModalText} />
+          </View>}
+      <VaultBindings.CardForm
+        id=formId vaultDetails=vaultDetailsProp onChange=onFormChange onError=onFormError>
+        <View style={s({width: boxWidth->dp})}>
+          <View
+            style={array([
+              bgColor,
+              s({
+                backgroundColor: component.background,
+                borderWidth,
+                borderRadius,
+                height: (inputHeight *. 0.9)->dp,
+                flexDirection: #row,
+                borderColor: isCvcValid
+                  ? isCvcFocus ? primaryColor : normalTextInputBoderColor
+                  : errorTextInputColor,
+                width: boxWidth->dp,
+                paddingHorizontal: 13.->dp,
+                alignItems: #center,
+                justifyContent: #center,
+              }),
+              shadowStyle,
+            ])}>
+            <VaultInput
+              elementType="cardCvc"
+              height={inputHeight *. 0.9}
+              reference=cvcRef
+              label=localeObject.cvcTextLabel
+              active=isCvcFocus
+              empty={cvcState->Option.mapOr(true, field => field.empty)}
+              valid=isCvcValid
+              useProviderIcon
+              iconRight=?{hideCvcIcon || useProviderIcon
+                ? None
+                : Some(
+                    <Icon
+                      name={cvcState->Option.mapOr(false, field => field.complete)
+                        ? "cvvfilled"
+                        : "cvvempty"}
+                      height=35.
+                      width=35.
+                      fill="black"
+                    />,
+                  )}
+              options=savedCard
+              placeholder={hideCardExpiry
+                ? placeholderCVC->Option.getOr(localeObject.cvcTextLabel)
+                : "123"}
+              onFocus={_ => setIsCvcFocus(_ => true)}
+              onBlur={_ => {
+                setIsCvcFocus(_ => false)
+                setHasBlurred(_ => true)
+              }}
+            />
+          </View>
+        </View>
+      </VaultBindings.CardForm>
+    </View>
+    {errorMsgText->Option.isSome && !hideCVCError ? <ErrorText text=errorMsgText /> : React.null}
+    <ErrorText text={mountError} />
+  </View>
+}

--- a/src/components/vault/VaultInput.res
+++ b/src/components/vault/VaultInput.res
@@ -1,0 +1,132 @@
+open ReactNative
+open Style
+
+@react.component
+let make = (
+  ~elementType: string,
+  ~height: float,
+  ~placeholder: string,
+  ~label: string,
+  ~active: bool,
+  ~empty: bool,
+  ~valid: bool,
+  ~iconRight: option<React.element>=?,
+  ~useProviderIcon: bool=false,
+  ~reference: VaultBindings.fieldRef,
+  ~onFocus,
+  ~onBlur,
+  ~onChange=?,
+  ~onReady=?,
+  ~options: option<VaultBindings.fieldOptions>=?,
+  ~testID: string="",
+) => {
+  let {
+    component,
+    dangerColor,
+    placeholderColor,
+    placeholderTextSizeAdjust,
+    fontScale,
+  } = ThemebasedStyle.useThemeBasedStyle()
+  let fontFamily = FontFamily.useCustomFontFamily()
+  let animatedValue = AnimatedValue.useAnimatedValue(0.)
+  let lifted = active || !empty
+  React.useEffect1(() => {
+    Animated.timing(
+      animatedValue,
+      {
+        toValue: (lifted ? 1. : 0.)->Animated.Value.Timing.fromRawValue,
+        duration: 200.,
+        useNativeDriver: false,
+      },
+    )->Animated.start
+    None
+  }, [lifted])
+  let inputHeight = height *. 0.7
+  let styles: VaultBindings.fieldStyles = {
+    container: s({height: inputHeight->dp, width: 100.->pct}),
+    input: useProviderIcon
+      ? s({
+          height: inputHeight->dp,
+          width: 100.->pct,
+          paddingVertical: 0.->dp,
+          color: valid ? component.color : dangerColor,
+          fontFamily,
+          fontSize: (16. +. placeholderTextSizeAdjust) *. fontScale,
+        })
+      : s({
+          height: inputHeight->dp,
+          width: 100.->pct,
+          padding: 0.->dp,
+          color: valid ? component.color : dangerColor,
+          fontFamily,
+          fontSize: (16. +. placeholderTextSizeAdjust) *. fontScale,
+        }),
+  }
+  let unstyled = !useProviderIcon
+  <>
+    <View style={s({flex: 1., height: 100.->pct, justifyContent: #"flex-end"})}>
+      <Animated.View
+        pointerEvents=#none
+        style={s({
+          position: #absolute,
+          top: 0.->dp,
+          height: animatedValue
+          ->Animated.Interpolation.interpolate({
+            inputRange: [0., 1.],
+            outputRange: [
+              "100%",
+              `${((height +. 10.) /. 1.4)->Float.toString}%`,
+            ]->Animated.Interpolation.fromStringArray,
+          })
+          ->Animated.StyleProp.size,
+          justifyContent: #center,
+        })}>
+        <Animated.Text
+          numberOfLines=1
+          style={s({
+            fontFamily,
+            fontWeight: lifted ? #500 : #normal,
+            color: placeholderColor,
+            fontSize: animatedValue
+            ->Animated.Interpolation.interpolate({
+              inputRange: [0., 1.],
+              outputRange: [
+                (16. +. placeholderTextSizeAdjust) *. fontScale,
+                11. +. placeholderTextSizeAdjust,
+              ]->Animated.Interpolation.fromFloatArray,
+            })
+            ->Animated.StyleProp.float,
+          })}>
+          {React.string(lifted ? label : placeholder)}
+        </Animated.Text>
+      </Animated.View>
+      {switch elementType {
+      | "cardNumber" =>
+        <VaultBindings.CardNumberField
+          ref=reference unstyled styles placeholder="" testID onFocus onBlur ?onChange ?onReady
+        />
+      | "cardExpiry" =>
+        <VaultBindings.CardExpiryField
+          ref=reference unstyled styles placeholder="" testID onFocus onBlur ?onChange ?onReady
+        />
+      | _ =>
+        <VaultBindings.CardCVCField
+          ref=reference
+          unstyled
+          styles
+          placeholder=""
+          testID
+          onFocus
+          onBlur
+          ?onChange
+          ?onReady
+          ?options
+        />
+      }}
+    </View>
+    {switch useProviderIcon ? None : iconRight {
+    | Some(icon) => <View pointerEvents=#none> icon </View>
+    | None => React.null
+    }}
+  </>
+}

--- a/src/contexts/CardStrategyContext.res
+++ b/src/contexts/CardStrategyContext.res
@@ -1,0 +1,70 @@
+type refusal =
+  | UnreadableVaultingAction
+  | VaultUnavailable
+
+type strategy =
+  | Pending
+  | DirectCard
+  | VaultCard(VaultDetailsType.vaultDetails)
+  | Refused(refusal)
+
+type formState = {
+  isValid: bool,
+  showErrors: bool,
+}
+
+let defaultFormState = {isValid: false, showErrors: false}
+
+type cardStrategyData = {
+  strategy: strategy,
+  getFormState: string => formState,
+  setFormValid: (string, bool) => unit,
+  setShowErrors: (string, bool) => unit,
+}
+
+let cardStrategyContext = React.createContext({
+  strategy: Pending,
+  getFormState: _ => defaultFormState,
+  setFormValid: (_, _) => (),
+  setShowErrors: (_, _) => (),
+})
+
+module Provider = {
+  let make = React.Context.provider(cardStrategyContext)
+}
+
+@react.component
+let make = (~children, ~strategy: strategy) => {
+  let (formStates, setFormStates) = React.useState(() => Dict.make())
+
+  let getFormState = React.useCallback1(
+    formId => formStates->Dict.get(formId)->Option.getOr(defaultFormState),
+    [formStates],
+  )
+
+  let update = React.useCallback1((formId, f) => {
+    setFormStates(prev => {
+      let current = prev->Dict.get(formId)->Option.getOr(defaultFormState)
+      let next = f(current)
+      if next.isValid === current.isValid && next.showErrors === current.showErrors {
+        prev
+      } else {
+        let copy = prev->Dict.copy
+        copy->Dict.set(formId, next)
+        copy
+      }
+    })
+  }, [setFormStates])
+
+  let setFormValid = React.useCallback1(
+    (formId, isValid) => update(formId, s => {...s, isValid}),
+    [update],
+  )
+
+  let setShowErrors = React.useCallback1(
+    (formId, showErrors) => update(formId, s => {...s, showErrors}),
+    [update],
+  )
+
+  <Provider value={strategy, getFormState, setFormValid, setShowErrors}> children </Provider>
+}

--- a/src/hooks/VaultCardSubmitHook.res
+++ b/src/hooks/VaultCardSubmitHook.res
@@ -1,0 +1,75 @@
+type shape =
+  | WholeCard
+  | SavedCardCvc
+
+let useVaultCardSubmit = () => {
+  let {getFormState, setShowErrors} = React.useContext(CardStrategyContext.cardStrategyContext)
+  let (loading, setLoading) = React.useContext(LoadingContext.loadingContext)
+  let handleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
+  let notifyValidationFailure = UseWidgetActions.useNotifyValidationFailure()
+  let logger = LoggerHook.useLoggerHook()
+
+  let inFlightRef = React.useRef(false)
+  let loadingRef = React.useRef(loading)
+  loadingRef.current = loading
+
+  React.useCallback6((~formId: string, ~shape: shape, ~onTokenized: Dict.t<JSON.t> => unit) => {
+    let refuse = () => {
+      setShowErrors(formId, true)
+      notifyValidationFailure()
+    }
+
+    let fail = message => {
+      setLoading(FillingDetails)
+      handleSuccessFailure(
+        ~apiResStatus={...PaymentConfirmTypes.defaultConfirmError, message},
+        ~closeSDK=false,
+        (),
+      )
+    }
+
+    let isBusy = switch loadingRef.current {
+    | ProcessingPayments | ProcessingPaymentsWithOverlay => true
+    | _ => false
+    }
+
+    if inFlightRef.current || isBusy {
+      ()
+    } else if !(getFormState(formId).isValid) {
+      refuse()
+    } else {
+      inFlightRef.current = true
+      setLoading(ProcessingPayments)
+      let settle = () => inFlightRef.current = false
+      VaultBindings.tokenizeForm(formId)
+      ->Promise.thenResolve(result => {
+        settle()
+        let outcome = switch shape {
+        | WholeCard => VaultTokenNormalizer.normalizeNewCardTokenizeResult(result)
+        | SavedCardCvc => VaultTokenNormalizer.normalizeSavedCardTokenizeResult(result)
+        }
+        switch outcome {
+        | Tokenized(fragment) => onTokenized(fragment)
+        | NeedsInput =>
+          setLoading(FillingDetails)
+          refuse()
+        | Failed({message, reason}) =>
+          logger(
+            ~logType=ERROR,
+            ~value=`Vault tokenize result refused: ${reason}`,
+            ~category=USER_ERROR,
+            ~eventName=VAULT_TOKENIZE,
+            (),
+          )
+          fail(message)
+        }
+      })
+      ->Promise.catch(_ => {
+        settle()
+        fail(VaultTokenNormalizer.fallbackMessage)
+        Promise.resolve()
+      })
+      ->ignore
+    }
+  }, (getFormState, setShowErrors, setLoading, notifyValidationFailure, handleSuccessFailure, logger))
+}

--- a/src/pages/payment/PaymentMethod.res
+++ b/src/pages/payment/PaymentMethod.res
@@ -126,27 +126,15 @@ let make = (
       tabDict,
       paymentMethodStr,
     ) = switch paymentMethodData.payment_method {
-    | CARD =>
-      switch nickname {
-      | Some(name) => (
-          [
-            (
-              "payment_method_data",
-              [
-                (
-                  paymentMethodData.payment_method_str,
-                  [("nick_name", name->Js.Json.string)]->Dict.fromArray->Js.Json.object_,
-                ),
-              ]
-              ->Dict.fromArray
-              ->Js.Json.object_,
-            ),
-          ]->Dict.fromArray,
-          tabDict,
-          paymentMethodData.payment_method_str,
-        )
-      | None => (Dict.make(), tabDict, paymentMethodData.payment_method_str)
-      }
+    | CARD => (
+        PaymentUtils.nicknamePaymentMethodData(
+          ~tabDict,
+          ~paymentMethodStr=paymentMethodData.payment_method_str,
+          ~nickname,
+        ),
+        tabDict,
+        paymentMethodData.payment_method_str,
+      )
     | REWARD => (
         [
           ("payment_method_data", paymentMethodData.payment_method_str->Js.Json.string),
@@ -206,6 +194,8 @@ let make = (
       ~nativeProp,
       ~payment_method_str=paymentMethodStr,
       ~payment_method_type=paymentMethodData.payment_method_type,
+      ~payment_token=?tabDict->Dict.get("payment_token")->Option.flatMap(JSON.Decode.string),
+      ~isVaultedNewCard=PaymentUtils.isVaultedNewCard(tabDict),
       ~payment_method_data=?CommonUtils.mergeDict(paymentMethodDataDict, tabDict)->Dict.get(
         "payment_method_data",
       ),

--- a/src/pages/payment/SavedPaymentMethod.res
+++ b/src/pages/payment/SavedPaymentMethod.res
@@ -85,6 +85,41 @@ module CVVComponent = {
     </View>
   }
 }
+module SavedCardCvcInput = {
+  @react.component
+  let make = (
+    ~savedPaymentMethod: ClientResponseType.customerPaymentMethod,
+    ~savedCardCvv,
+    ~setSavedCardCvv,
+    ~hideCardExpiry,
+    ~hideCVCError,
+    ~hideCvcIcon,
+    ~placeholderCVC,
+  ) => {
+    let {strategy} = React.useContext(CardStrategyContext.cardStrategyContext)
+    switch strategy {
+    | DirectCard =>
+      <CVVComponent
+        savedCardCvv
+        setSavedCardCvv
+        cardScheme={savedPaymentMethod.card
+        ->Option.map(card => card.card_network)
+        ->Option.getOr("")}
+        hideCardExpiry
+        hideCVCError
+        hideCvcIcon
+        placeholderCVC
+      />
+    | VaultCard(vaultDetails) =>
+      <VaultCvcElement
+        savedPaymentMethod vaultDetails hideCardExpiry hideCVCError hideCvcIcon placeholderCVC
+      />
+    | Pending => React.null
+    | Refused(_) => <ErrorText text=PaymentConfirmTypes.defaultConfigError.message />
+    }
+  }
+}
+
 module PMWithNickNameComponent = {
   @react.component
   let make = (
@@ -348,12 +383,10 @@ module PaymentMethodListView = {
           isPaymentMethodSelected &&
           savedPaymentMethod.payment_method === CARD &&
           savedPaymentMethod.requires_cvv
-            ? <CVVComponent
+            ? <SavedCardCvcInput
+                savedPaymentMethod
                 savedCardCvv
                 setSavedCardCvv
-                cardScheme={savedPaymentMethod.card
-                ->Option.map(card => card.card_network)
-                ->Option.getOr("")}
                 hideCardExpiry
                 hideCVCError=nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.hideCVCError
                 hideCvcIcon={nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.cvcIcon ===
@@ -381,12 +414,10 @@ module PaymentMethodListView = {
       savedPaymentMethod.payment_method === CARD &&
       savedPaymentMethod.requires_cvv &&
       !hideCardExpiry
-        ? <CVVComponent
+        ? <SavedCardCvcInput
+            savedPaymentMethod
             savedCardCvv
             setSavedCardCvv
-            cardScheme={savedPaymentMethod.card
-            ->Option.map(card => card.card_network)
-            ->Option.getOr("")}
             hideCardExpiry
             hideCVCError=nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.hideCVCError
             hideCvcIcon={nativeProp.configuration.paymentMethodLayout.savedMethodCustomization.cvcIcon ===

--- a/src/pages/payment/SavedPaymentSheet.res
+++ b/src/pages/payment/SavedPaymentSheet.res
@@ -21,6 +21,10 @@ let make = (
   let {getRequiredFieldsForButton, nickname} = React.useContext(
     DynamicFieldsContext.dynamicFieldsContext,
   )
+  let {strategy, getFormState, setShowErrors} = React.useContext(
+    CardStrategyContext.cardStrategyContext,
+  )
+  let submitVaultCard = VaultCardSubmitHook.useVaultCardSubmit()
   let (_, setLoading) = React.useContext(LoadingContext.loadingContext)
 
   let showAlert = AlertHook.useAlerts()
@@ -50,6 +54,15 @@ let make = (
     setSelectedToken(_ => token)
   }, [setSelectedToken])
 
+  let vaultCvcFormId = selectedToken->Option.mapOr("", VaultCvcElement.formIdFor)
+  let isVaultCvc = switch (selectedToken, strategy) {
+  | (Some(token), CardStrategyContext.VaultCard(_)) =>
+    token.payment_method === CARD && token.requires_cvv
+  | _ => false
+  }
+  let vaultCvcValid = isVaultCvc && getFormState(vaultCvcFormId).isValid
+  let hasCvcInput = isVaultCvc ? vaultCvcValid : savedCardCvv->Option.isSome
+
   React.useEffect1(() => {
     // if !isScreenFocus {
     setSelectedToken(customerPaymentMethods->Array.get(0))
@@ -73,7 +86,10 @@ let make = (
   } = ThemebasedStyle.useThemeBasedStyle()
   let getShadowStyle = ShadowHook.useGetShadowStyle(~shadowConfig, ())
 
-  let processRequestSaved = (token: ClientResponseType.customerPaymentMethod) => {
+  let processRequestSaved = (
+    token: ClientResponseType.customerPaymentMethod,
+    ~vaultPaymentMethodData: option<JSON.t>=?,
+  ) => {
     setLoading(ProcessingPayments)
 
     let errorCallback = (~errorMessage: PaymentConfirmTypes.error, ~closeSDK, ()) => {
@@ -119,6 +135,7 @@ let make = (
         ~payment_method_type=?{
           token.payment_method === CARD ? None : Some(token.payment_method_type)
         },
+        ~vaultPaymentMethodData?,
       )
     }
 
@@ -425,28 +442,45 @@ let make = (
   let handlePress = _ => {
     switch (
       selectedToken,
-      !showDisclaimer ||
-      (showDisclaimer && (isSaveCardCheckboxSelected || savedCardCvv->Option.isNone)),
+      !showDisclaimer || (showDisclaimer && (isSaveCardCheckboxSelected || !hasCvcInput)),
     ) {
     | (Some(token), true) =>
       switch token.payment_method {
       | CARD =>
-        token.requires_cvv &&
-        (savedCardCvv->Option.isNone ||
-          !Validation.cvcNumberInRange(
-            savedCardCvv->Option.getOr(""),
-            token.card
-            ->Option.map(card => card.card_network)
-            ->Option.getOr(""),
-          ))
-          ? {
-              if savedCardCvv->Option.isNone {
-                setSavedCardCvv(_ => Some(""))
+        switch strategy {
+        | CardStrategyContext.VaultCard(_) if token.requires_cvv =>
+          if !vaultCvcValid {
+            setShowErrors(vaultCvcFormId, true)
+            setLoading(FillingDetails)
+            notifyValidationFailure()
+          } else {
+            submitVaultCard(~formId=vaultCvcFormId, ~shape=SavedCardCvc, ~onTokenized=vaultPmd =>
+              processRequestSaved(
+                token,
+                ~vaultPaymentMethodData=?vaultPmd->Dict.get("payment_method_data"),
+              )
+            )
+          }
+        | CardStrategyContext.Pending | CardStrategyContext.Refused(_) if token.requires_cvv =>
+          setLoading(FillingDetails)
+        | _ =>
+          token.requires_cvv &&
+          (savedCardCvv->Option.isNone ||
+            !Validation.cvcNumberInRange(
+              savedCardCvv->Option.getOr(""),
+              token.card
+              ->Option.map(card => card.card_network)
+              ->Option.getOr(""),
+            ))
+            ? {
+                if savedCardCvv->Option.isNone {
+                  setSavedCardCvv(_ => Some(""))
+                }
+                setLoading(FillingDetails)
+                notifyValidationFailure()
               }
-              setLoading(FillingDetails)
-              notifyValidationFailure()
-            }
-          : processRequestSaved(token)
+            : processRequestSaved(token)
+        }
       | WALLET =>
         switch token.payment_method_type_wallet {
         | APPLE_PAY =>
@@ -586,12 +620,14 @@ let make = (
     None
   }, [selectedToken])
 
-  React.useEffect2(() => {
+  React.useEffect4(() => {
     switch selectedToken {
     | Some(token) =>
       let isFormComplete = switch token.payment_method {
       | CARD =>
-        if token.requires_cvv {
+        if isVaultCvc {
+          vaultCvcValid
+        } else if token.requires_cvv {
           switch savedCardCvv {
           | Some(cvv) =>
             cvv->String.length > 0 &&
@@ -632,7 +668,7 @@ let make = (
     | None => ()
     }
     None
-  }, (selectedToken, savedCardCvv))
+  }, (selectedToken, savedCardCvv, isVaultCvc, vaultCvcValid))
 
   React.useEffect(() => {
     if isScreenFocus {
@@ -660,6 +696,8 @@ let make = (
     errorText,
     isSaveCardCheckboxSelected,
     isScreenFocus,
+    strategy,
+    vaultCvcValid,
   ))
 
   <ErrorBoundary level={FallBackScreen.Screen} rootTag=nativeProp.rootTag>
@@ -700,7 +738,7 @@ let make = (
         ?maxVisibleItems
       />
     </View>
-    {showDisclaimer && savedCardCvv->Option.isSome
+    {showDisclaimer && hasCvcInput
       ? <View style={s({paddingHorizontal: 2.->dp})}>
           // <Space />
           <ClickableTextElement

--- a/src/routes/NavigationRouter.res
+++ b/src/routes/NavigationRouter.res
@@ -7,6 +7,9 @@ let make = () => {
   let (clientResponse, setClientResponse) = React.useState(_ => None)
   let (sessionTokenData, setSessionTokenData) = React.useState(_ => None)
   let (sdkConfigData, setSdkConfigData) = React.useState(_ => None)
+  let (sessionAnswered, setSessionAnswered) = React.useState(_ => false)
+  let (vaultDetails, setVaultDetails) = React.useState(_ => None)
+  let (vaultingAction, setVaultingAction) = React.useState(_ => None)
 
   let handleSuccessFailure = AllPaymentHooks.useHandleSuccessFailure()
   let (loading, _) = React.useContext(LoadingContext.loadingContext)
@@ -46,6 +49,9 @@ let make = () => {
     if nativeProp.sdkState !== CvcWidget && !alreadyFetched {
       fetchedCredentialsKey.current = Some(sessionCredentialsKey)
       let requestKey = sessionCredentialsKey
+      setSessionAnswered(_ => false)
+      setVaultDetails(_ => None)
+      setVaultingAction(_ => None)
 
       let isRequestCurrent = () =>
         switch fetchedCredentialsKey.current {
@@ -108,6 +114,7 @@ let make = () => {
         } else {
           let parsed = SdkConfigParser.itemToObjMapper(configResponse)
           if PaymentUtils.isValidSdkConfig(parsed) {
+            setVaultingAction(_ => Some(PaymentUtils.readVaultingAction(configResponse)))
             setSdkConfigData(_ => Some(parsed))
           } else {
             exitSheetOnce(~apiResStatus=PaymentConfirmTypes.defaultConfigError)
@@ -117,7 +124,9 @@ let make = () => {
 
       let entry = SessionStore.getOrStart(~key=requestKey, ~fetchers=sessionFetchers)
 
-      let handleSessionTokenResponse = sessionTokenData =>
+      let handleSessionTokenResponse = sessionTokenData => {
+        setSessionAnswered(_ => true)
+        setVaultDetails(_ => VaultDetailsType.parseVaultDetails(sessionTokenData))
         if sessionTokenData->ErrorUtils.isError {
           if sessionTokenData->ErrorUtils.getErrorCode == "\"IR_16\"" {
             errorOnApiCalls(ErrorUtils.errorWarning.usedCL, ())
@@ -130,6 +139,7 @@ let make = () => {
           | None => setSessionTokenData(_ => Some([]))
           }
         }
+      }
 
       // Prefetched entries may already be resolved at mount; applying them then
       // would parse and re-render during the sheet's entrance animation. The
@@ -188,11 +198,30 @@ let make = () => {
     }
   }, (clientResponse, sdkConfigData, paymentMethodOrder, hiddenPaymentMethods))
 
+  let cardStrategy = React.useMemo3(() => {
+    let strategy: CardStrategyContext.strategy = switch vaultingAction {
+    | None => Pending
+    | Some(PaymentUtils.SkipVaulting) => DirectCard
+    | Some(PaymentUtils.UnreadableVaulting) => Refused(UnreadableVaultingAction)
+    | Some(PaymentUtils.TokenizeVaulting) =>
+      if !sessionAnswered {
+        Pending
+      } else {
+        switch vaultDetails {
+        | Some(details) => VaultCard(details)
+        | None => Refused(VaultUnavailable)
+        }
+      }
+    }
+    strategy
+  }, (vaultingAction, sessionAnswered, vaultDetails))
+
   BackHandlerHook.useBackHandler(~loading, ~sdkState=nativeProp.sdkState)
 
   UpdateIntentHook.useUpdateIntentListener()
 
   <AllApiDataContextNew clientData sessionTokenData sdkConfigData>
+   <CardStrategyContext strategy=cardStrategy>
     // TODO: Pass DynamicFieldsContext to only required components.
     // GO to NavigatorRouter.res and wrap only the components which require DynamicFieldsContext.
     <DynamicFieldsContext>
@@ -214,5 +243,6 @@ let make = () => {
       | PaymentMethodsManagement => React.null
       }}
     </DynamicFieldsContext>
+   </CardStrategyContext>
   </AllApiDataContextNew>
 }

--- a/src/types/AllApiDataTypes/VaultDetailsType.res
+++ b/src/types/AllApiDataTypes/VaultDetailsType.res
@@ -1,0 +1,70 @@
+open Utils
+
+type vaultConfig =
+  | HyperswitchVault({sdkAuthorization: string})
+  | VgsVault({vaultId: string, environment: option<string>})
+
+type vaultDetails = {
+  vaultTypeStr: string,
+  config: vaultConfig,
+}
+
+let optionalString = (dict, key) =>
+  dict->Dict.get(key)->Option.flatMap(JSON.Decode.string)->getNonEmptyOption
+
+let environmentName = (env: GlobalVars.envType) =>
+  switch env {
+  | INTEG => "INTEG"
+  | SANDBOX => "SANDBOX"
+  | PROD => "PROD"
+  }
+
+let toCardFormProp = (details: vaultDetails, ~environment: GlobalVars.envType): JSON.t => {
+  let data = switch details.config {
+  | HyperswitchVault({sdkAuthorization}) =>
+    [
+      ("sdkAuthorization", sdkAuthorization->JSON.Encode.string),
+      ("environment", environment->environmentName->JSON.Encode.string),
+    ]->Dict.fromArray
+  | VgsVault({vaultId, environment}) =>
+    let arr = [("vaultId", vaultId->JSON.Encode.string)]
+    environment->Option.forEach(v => arr->Array.push(("environment", v->JSON.Encode.string)))
+    arr->Dict.fromArray
+  }
+  [
+    ("vaultType", details.vaultTypeStr->JSON.Encode.string),
+    ("vaultData", data->JSON.Encode.object),
+  ]
+  ->Dict.fromArray
+  ->JSON.Encode.object
+}
+
+let parseVaultDetails = (sessionTokenResponse: JSON.t): option<vaultDetails> => {
+  sessionTokenResponse
+  ->JSON.Decode.object
+  ->Option.flatMap(root => root->Dict.get("vault_details"))
+  ->Option.flatMap(JSON.Decode.object)
+  ->Option.flatMap(vd => {
+    let vaultTypeStr =
+      vd->optionalString("vault_type")->Option.map(String.toLowerCase)->Option.getOr("")
+    let vaultData = vd->Dict.get("vault_data")->Option.flatMap(JSON.Decode.object)
+
+    switch (vaultTypeStr, vaultData) {
+    | ("hyperswitch", Some(data)) =>
+      data
+      ->optionalString("sdk_authorization")
+      ->Option.map(sdkAuthorization => {
+        vaultTypeStr: "hyperswitch",
+        config: HyperswitchVault({sdkAuthorization: sdkAuthorization}),
+      })
+    | ("vgs", Some(data)) =>
+      data
+      ->optionalString("vault_id")
+      ->Option.map(vaultId => {
+        vaultTypeStr: "vgs",
+        config: VgsVault({vaultId, environment: data->optionalString("environment")}),
+      })
+    | _ => None
+    }
+  })
+}

--- a/src/types/LoggerTypes.res
+++ b/src/types/LoggerTypes.res
@@ -57,6 +57,7 @@ type eventName =
   | POST_SESSION_TOKENS_CALL_INIT
   | POST_SESSION_TOKENS_CALL
   | CARD_SCHEME_SELECTION
+  | VAULT_TOKENIZE
 
 type logFile = {
   timestamp: string,

--- a/src/utility/logics/PaymentUtils.res
+++ b/src/utility/logics/PaymentUtils.res
@@ -36,6 +36,68 @@ let shouldShowSaveDetailsCheckbox = (
   | _ => false
   }
 
+type vaultingAction = SkipVaulting | TokenizeVaulting | UnreadableVaulting
+
+let readVaultingAction = (sdkConfigResponse: JSON.t): vaultingAction =>
+  sdkConfigResponse
+  ->JSON.Decode.object
+  ->Option.flatMap(root => root->Dict.get("account_config"))
+  ->Option.flatMap(JSON.Decode.object)
+  ->Option.flatMap(accountConfig => accountConfig->Dict.get("profile"))
+  ->Option.flatMap(JSON.Decode.object)
+  ->Option.flatMap(profile => profile->Dict.get("vaulting_action"))
+  ->Option.flatMap(JSON.Decode.string)
+  ->Option.mapOr(UnreadableVaulting, raw =>
+    switch raw->String.trim->String.toLowerCase {
+    | "skip" => SkipVaulting
+    | "tokenize" => TokenizeVaulting
+    | _ => UnreadableVaulting
+    }
+  )
+
+let hasExternalVaultCard = (tabDict: Dict.t<JSON.t>) =>
+  tabDict
+  ->Dict.get("payment_method_data")
+  ->Option.flatMap(JSON.Decode.object)
+  ->Option.flatMap(pmd => pmd->Dict.get("vault_card"))
+  ->Option.isSome
+
+let hasVaultPaymentToken = (tabDict: Dict.t<JSON.t>) =>
+  tabDict
+  ->Dict.get("payment_token")
+  ->Option.flatMap(JSON.Decode.string)
+  ->Utils.getNonEmptyOption
+  ->Option.isSome
+
+let isVaultedNewCard = (tabDict: Dict.t<JSON.t>) =>
+  hasVaultPaymentToken(tabDict) || hasExternalVaultCard(tabDict)
+
+let nicknamePaymentMethodData = (
+  ~tabDict: Dict.t<JSON.t>,
+  ~paymentMethodStr: string,
+  ~nickname: option<string>,
+): Dict.t<JSON.t> => {
+  let key = if hasExternalVaultCard(tabDict) {
+    Some("vault_card")
+  } else if hasVaultPaymentToken(tabDict) {
+    None
+  } else {
+    Some(paymentMethodStr)
+  }
+  switch (nickname, key) {
+  | (Some(name), Some(key)) =>
+    [
+      (
+        "payment_method_data",
+        [(key, [("nick_name", name->JSON.Encode.string)]->Dict.fromArray->JSON.Encode.object)]
+        ->Dict.fromArray
+        ->JSON.Encode.object,
+      ),
+    ]->Dict.fromArray
+  | _ => Dict.make()
+  }
+}
+
 let generateCardConfirmBody = (
   ~nativeProp: SdkTypes.nativeProp,
   ~payment_method_str: string,
@@ -52,6 +114,7 @@ let generateCardConfirmBody = (
   ~email=?,
   ~screen_height=?,
   ~screen_width=?,
+  ~isVaultedNewCard=false,
   (),
 ): PaymentConfirmTypes.redirectType => {
   let isMandate = payment_type !== NORMAL
@@ -68,7 +131,7 @@ let generateCardConfirmBody = (
     ?email,
     payment_type: ?payment_type_str,
     customer_acceptance: ?(
-      payment_token->Option.isNone &&
+      (payment_token->Option.isNone || isVaultedNewCard) &&
       (nativeProp.configuration.alwaysSendCustomerAcceptance ||
       isNicknameSelected && isMandate ||
       isMandate && !isNicknameSelected && !(isSaveCardCheckboxVisible->Option.getOr(false)) ||
@@ -128,6 +191,7 @@ let generateSavedCardConfirmBody = (
   ~screen_width=?,
   ~billing=?,
   ~payment_method_type=?,
+  ~vaultPaymentMethodData: option<JSON.t>=?,
 ): PaymentConfirmTypes.redirectType => {
   client_secret: ?switch nativeProp.paymentSessionConfig.sdkAuthorization->Utils.getNonEmptyOption {
   | Some(_) => None
@@ -136,13 +200,21 @@ let generateSavedCardConfirmBody = (
   payment_method,
   ?payment_method_type,
   payment_token,
-  card_cvc: ?(savedCardCvv->Option.isSome ? Some(savedCardCvv->Option.getOr("")) : None),
-  return_url: ?Utils.getCustomReturnAppUrl(~appId=nativeProp.sdkParams.appId),
-  payment_method_data: ?billing->Option.map(address =>
-    [("billing", address->Utils.getJsonObjectFromRecord)]
-    ->Dict.fromArray
-    ->JSON.Encode.object
+  card_cvc: ?(
+    vaultPaymentMethodData->Option.isNone && savedCardCvv->Option.isSome
+      ? Some(savedCardCvv->Option.getOr(""))
+      : None
   ),
+  return_url: ?Utils.getCustomReturnAppUrl(~appId=nativeProp.sdkParams.appId),
+  payment_method_data: ?{
+    let billingDict =
+      billing->Option.mapOr(Dict.make(), address =>
+        [("billing", address->Utils.getJsonObjectFromRecord)]->Dict.fromArray
+      )
+    let vaultDict = vaultPaymentMethodData->Option.flatMap(JSON.Decode.object)->Option.getOr(Dict.make())
+    let merged = CommonUtils.mergeDict(billingDict, vaultDict)
+    merged->Dict.toArray->Array.length > 0 ? Some(merged->JSON.Encode.object) : None
+  },
   payment_type: ?payment_type_str,
   browser_info: {
     user_agent: Utils.resolveUserAgent(~userAgent=nativeProp.sdkParams.userAgent),

--- a/src/utility/logics/VaultTokenNormalizer.res
+++ b/src/utility/logics/VaultTokenNormalizer.res
@@ -1,0 +1,141 @@
+type failure = {
+  message: string,
+  reason: string,
+}
+
+type outcome =
+  | Tokenized(Dict.t<JSON.t>)
+  | NeedsInput
+  | Failed(failure)
+
+let fallbackMessage =
+  PaymentConfirmTypes.defaultConfirmError.message->Option.getOr("The card could not be processed.")
+
+let refuse = reason => Failed({message: fallbackMessage, reason})
+
+let stringAt = (dict: Dict.t<JSON.t>, key) =>
+  dict->Dict.get(key)->Option.flatMap(JSON.Decode.string)->Utils.getNonEmptyOption
+
+let paymentTokenFragment = token => [("payment_token", JSON.Encode.string(token))]->Dict.fromArray
+
+let paymentMethodDataFragment = (~key, inner: Dict.t<JSON.t>) =>
+  [
+    ("payment_method_data", [(key, inner->JSON.Encode.object)]->Dict.fromArray->JSON.Encode.object),
+  ]->Dict.fromArray
+
+let splitVaultExpiry = (expiry: string): option<(string, string)> => {
+  let fullYear = year => year->String.length === 2 ? "20" ++ year : year
+  let trimmed = expiry->String.trim
+  let parts = trimmed->String.split("/")->Array.map(String.trim)
+  switch parts {
+  | [month, year]
+    if month->String.length === 2 && (year->String.length === 2 || year->String.length === 4) =>
+    Some((month, fullYear(year)))
+  | _ =>
+    let digits = trimmed->String.replaceRegExp(%re("/\D/g"), "")
+    switch digits->String.length {
+    | 4 | 6 =>
+      Some((digits->String.slice(~start=0, ~end=2), fullYear(digits->String.sliceToEnd(~start=2))))
+    | _ => None
+    }
+  }
+}
+
+let vgsFields = (tokens: Dict.t<JSON.t>) =>
+  tokens->Dict.get("json")->Option.flatMap(JSON.Decode.object)->Option.getOr(tokens)
+
+let vgsCard = (fields: Dict.t<JSON.t>): result<Dict.t<JSON.t>, string> =>
+  switch (
+    fields->stringAt("card_number"),
+    fields->stringAt("card_cvc"),
+    fields->stringAt("expiration_date")->Option.flatMap(splitVaultExpiry),
+  ) {
+  | (Some(number), Some(cvc), Some((month, year))) =>
+    let card =
+      [
+        ("card_number", number),
+        ("card_cvc", cvc),
+        ("card_exp_month", month),
+        ("card_exp_year", year),
+      ]
+      ->Array.map(((key, value)) => (key, JSON.Encode.string(value)))
+      ->Dict.fromArray
+    fields
+    ->stringAt("card_holder")
+    ->Option.forEach(name => card->Dict.set("card_holder_name", JSON.Encode.string(name)))
+    Ok(card)
+  | _ => Error("vgs: echo lacks card_number, card_cvc or a readable expiration_date")
+  }
+
+let hyperswitchToken = (tokens: Dict.t<JSON.t>, ~onToken) =>
+  switch tokens->stringAt("payment_method_token") {
+  | Some(token) => onToken(token)
+  | None => refuse("hyperswitch: no payment_method_token")
+  }
+
+let classifyFailure = (result: VaultBindings.tokenizeResult) =>
+  switch result.status {
+  | "validation_error" => NeedsInput
+  | _ =>
+    switch result.error {
+    | Some(error) =>
+      switch error.code {
+      | "validation_error" | "incomplete_field_set" => NeedsInput
+      | code =>
+        Failed({
+          message: Some(error.message)->Utils.getNonEmptyOption->Option.getOr(fallbackMessage),
+          reason: code,
+        })
+      }
+    | None => refuse("error without details")
+    }
+  }
+
+let normalize = (
+  result: VaultBindings.tokenizeResult,
+  ~hyperswitch: string => outcome,
+  ~vgs: Dict.t<JSON.t> => outcome,
+) =>
+  if result.status !== "success" {
+    classifyFailure(result)
+  } else {
+    switch (result.vaultType, result.data->Option.flatMap(data => data.tokens)) {
+    | (_, None) => refuse("success without tokens")
+    | (Some("hyperswitch"), Some(tokens)) => hyperswitchToken(tokens, ~onToken=hyperswitch)
+    | (Some("vgs"), Some(tokens)) => vgs(vgsFields(tokens))
+    | (Some(other), Some(_)) => refuse("unsupported vault type " ++ other)
+    | (None, Some(_)) => refuse("success without vaultType")
+    }
+  }
+
+let normalizeNewCardTokenizeResult = (result: VaultBindings.tokenizeResult): outcome =>
+  result->normalize(
+    ~hyperswitch=token => Tokenized(paymentTokenFragment(token)),
+    ~vgs=fields =>
+      switch vgsCard(fields) {
+      | Ok(card) => Tokenized(paymentMethodDataFragment(~key="vault_card", card))
+      | Error(reason) => refuse(reason)
+      },
+  )
+
+let normalizeSavedCardTokenizeResult = (result: VaultBindings.tokenizeResult): outcome =>
+  result->normalize(
+    ~hyperswitch=token =>
+      Tokenized(
+        paymentMethodDataFragment(
+          ~key="card_token",
+          [("card_cvc_token", JSON.Encode.string(token))]->Dict.fromArray,
+        ),
+      ),
+    ~vgs=fields =>
+      switch fields->stringAt("card_cvc") {
+      | Some(cvcToken) =>
+        Tokenized(
+          paymentMethodDataFragment(
+            ~key="vault_card_token",
+            [("card_cvc", JSON.Encode.string(cvcToken))]->Dict.fromArray,
+          ),
+        )
+      | None => refuse("vgs: echo lacks card_cvc")
+      },
+  )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,6 +2972,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@juspay-tech/react-native-hyperswitch-payment-methods@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@juspay-tech/react-native-hyperswitch-payment-methods@npm:1.0.0"
+  peerDependencies:
+    "@basis-theory/react-native-elements": "*"
+    "@evervault/react-native": "*"
+    "@juspay-tech/react-native-hyperswitch-vault": "*"
+    "@vgs/collect-react-native": "*"
+    react: "*"
+    react-native: "*"
+    skyflow-react-native: "*"
+  peerDependenciesMeta:
+    "@basis-theory/react-native-elements":
+      optional: true
+    "@evervault/react-native":
+      optional: true
+    "@juspay-tech/react-native-hyperswitch-vault":
+      optional: true
+    "@vgs/collect-react-native":
+      optional: true
+    skyflow-react-native:
+      optional: true
+  checksum: 2f4ef7e1f2aafffb586b73657116305d0dbf48f5d525a13b88d2f29c7952d5c59eca8e26063ba8dec205718272d645a2091ad0a7402dd5f8713ff992028ad851
+  languageName: node
+  linkType: hard
+
 "@juspay-tech/react-native-hyperswitch-paypal@npm:^1.0.2":
   version: 1.0.2
   resolution: "@juspay-tech/react-native-hyperswitch-paypal@npm:1.0.2"
@@ -2990,6 +3016,17 @@ __metadata:
     react-native: "*"
     react-native-webview: "*"
   checksum: d8833cdabbf564bc219f2c06a34cf16d2d23ce21e6be541f6feac8b2f38ce5253dfa2c1279c7016cc781759e50c307d9ad136b5ba1a60c43986d71b32658da74
+  languageName: node
+  linkType: hard
+
+"@juspay-tech/react-native-hyperswitch-vault@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@juspay-tech/react-native-hyperswitch-vault@npm:1.0.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-svg: "*"
+  checksum: ad45cc1bb7021ed9519d286aeb4f29591a9c0f73b3b0744a0eaeeddbd1f83a28bcde4bdad678de12edba6e9e2749764b6e2162cbc5de99a648fffa065efae50f
   languageName: node
   linkType: hard
 
@@ -5502,6 +5539,16 @@ __metadata:
   version: 1.3.0
   resolution: "@ungap/structured-clone@npm:1.3.0"
   checksum: 64ed518f49c2b31f5b50f8570a1e37bde3b62f2460042c50f132430b2d869c4a6586f13aa33a58a4722715b8158c68cae2827389d6752ac54da2893c83e480fc
+  languageName: node
+  linkType: hard
+
+"@vgs/collect-react-native@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@vgs/collect-react-native@npm:1.2.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: cefea03a8fa0287cbece3c9772923096788994230c72705ea3c1b8e4da7da832c7c1a4a6a13ac43f67427c02ac4ea6c46b804cd3abd3b0fd303dac831ba4a546
   languageName: node
   linkType: hard
 
@@ -10662,8 +10709,10 @@ __metadata:
     "@commitlint/config-conventional": ^17.0.3
     "@glennsl/rescript-fetch": 0.2.3
     "@juspay-tech/react-native-hyperswitch-netcetera-3ds": ^0.2.2
+    "@juspay-tech/react-native-hyperswitch-payment-methods": 1.0.0
     "@juspay-tech/react-native-hyperswitch-paypal": ^1.0.2
     "@juspay-tech/react-native-hyperswitch-scancard": ^0.2.3
+    "@juspay-tech/react-native-hyperswitch-vault": 1.0.0
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.15
     "@react-native-community/cli": 20.1.0
     "@react-native-community/cli-platform-android": 20.1.0
@@ -10688,6 +10737,7 @@ __metadata:
     "@types/pako": ^2
     "@types/react": ^19.2.0
     "@types/react-test-renderer": ^19.1.0
+    "@vgs/collect-react-native": ^1.2.0
     babel-jest: ^29.6.3
     babel-loader: ^9.1.3
     babel-plugin-react-native-web: ^0.20.0


### PR DESCRIPTION
## Summary

Adds provider-vaulted card collection to the RN SDK. When a merchant profile opts into vaulting, the PAN/CVC are collected by a provider-owned secure field (Hyperswitch Vault or VGS) instead of a React Final Form TextInput, exchanged for a token, and only the token reaches `/payments/{id}/confirm`. Client-core never sees or transmits raw card data on these paths.

The SDK stays the confirm owner throughout — the vault is only ever asked for a token. Nothing about the existing direct-card flow changes.

Everything is driven by two independent backend answers:

| Source | Field | Meaning |
| --- | --- | --- |
| `GET /sdk-config` | `account_config.profile.vaulting_action` | `skip` → collect directly · `tokenize` → collect through a vault |
| `POST /payments/session_tokens` | `vault_details.{vault_type, vault_data}` | which vault, and its credentials |

---

## Architecture

### One decision, read everywhere: `CardStrategyContext`

`NavigationRouter` folds the two responses into a single value that every card renderer and every pay button reads:

```rescript
type strategy =
  | Pending
  | DirectCard
  | VaultCard(VaultDetailsType.vaultDetails)
  | Refused(UnreadableVaultingAction | VaultUnavailable)
```

`Pending` and `Refused` are deliberately distinct from `DirectCard`. A config we cannot read must never fall through to sending a raw PAN, and a config that hasn't arrived yet must not flash a refusal at the customer. Pending renders nothing and the pay button is a no-op; Refused renders the existing config-error copy.

`vaulting_action` is read off the unparsed sdk-config response (`PaymentUtils.readVaultingAction`) rather than through shared-code's parser, because that parser maps every unrecognised string to `Skip` — and `Skip` means "send the raw PAN". Anything that isn't an explicit `"skip"` or `"tokenize"` is reported as unreadable and refused.

Only a tokenize profile waits on `session_tokens`; a skip profile renders exactly as fast as it does today.

### Where each piece lives

| File | Responsibility |
| --- | --- |
| `VaultDetailsType.res` | Parses `vault_details`; builds the camelCase `vaultDetails` prop the package expects |
| `CardStrategyContext.res` | The strategy + per-form validity/showErrors, keyed by form id |
| `VaultBindings.res` | Externals for `@juspay-tech/react-native-hyperswitch-payment-methods@1.0.0` |
| `VaultInput.res` | One provider field inside the SDK's own input chrome |
| `VaultCardElement.res` | The new-card form (number / expiry / CVC), in CardElement's layout |
| `VaultCvcElement.res` | The saved-card CVC field, in CVVComponent's layout |
| `VaultCardSubmitHook.res` | The single submit owner: gate → tokenize → hand the fragment to the caller's confirm |
| `VaultTokenNormalizer.res` | The only place a provider result becomes a confirm fragment |

Form ids are namespaced so two card tabs (credit + debit) or a sheet and a tab never share state: `tab-<pm_type>`, `sheet-<pm_type>`, `saved-<payment_method_id>`.

### The normalisation boundary

Provider knowledge stops at `VaultTokenNormalizer`. Callers see `Tokenized(fragment)`, `NeedsInput`, or `Failed({message, reason})` — never a provider's raw answer. The reason carries key names and codes only, never a value or a fragment of one.

### One press, one tokenize, one confirm

`VaultCardSubmitHook` flips an in-flight ref before the first await, so a second press in the same tick is dropped even though the button hasn't re-rendered as disabled yet. Once the fragment is handed on, the confirm's own `ProcessingPayments` state keeps the hook closed until that confirm settles — read through a ref so a stale closure (the widget host calls `handlePress` directly) still sees the live value.

---

## The five flows: request → response → confirm

### 1. Direct card (unchanged) — `vaulting_action: "skip"`

📹 **Recording:** (attach)

No vault call. `CardElement` collects, RFF validates, and the confirm carries the PAN as it always has:

```json
POST /payments/{id}/confirm

{
  "payment_method": "card",
  "payment_method_data": {
    "card": {
      "card_number": "4242…",
      "card_exp_month": "12",
      "card_exp_year": "2030",
      "card_cvc": "123",
      "nick_name": "My card"
    }
  }
}
```

---

### 2. Hyperswitch Vault — new card

📹 **Recording:** (attach)

The package mounts `@juspay-tech/react-native-hyperswitch-vault`, which posts the card to the payment-method session itself and returns a token.

**Vault call (made by the library, not client-core):**

```http
POST /v1/payment-method-sessions/{session_id}/confirm
Authorization: <sdk_authorization from vault_details>
```

```json
{
  "payment_method_data": {
    "card": {
      "card_number": "…",
      "card_exp_month": "…",
      "card_exp_year": "…",
      "card_cvc": "…"
    }
  }
}
```

**Response → token D:**

```json
{
  "associated_payment_methods": [
    {
      "payment_method_token": {
        "type": "payment_method_session_token",
        "data": "token_…"
      }
    }
  ]
}
```

**Confirm:**

```http
POST /payments/{id}/confirm
```

```json
{
  "payment_method": "card",
  "payment_token": "<D>"
}
```

A vaulted new card carries a `payment_token` like a stored card does, but its acceptance has never been captured — so `generateCardConfirmBody` takes an `~isVaultedNewCard` flag and still emits `customer_acceptance`. Without it the save-card, nickname and mandate flows would confirm with no acceptance at all.

**Nickname:** a Hyperswitch-vaulted new card is only a top-level `payment_token`. The backend's `vault_card` requires the whole aliased card, so a `nick_name`-only `vault_card` is refused (422) or misrouted into the external-vault proxy. `payment-methods@1.0.0` offers no way to hand the nickname to the PMS confirm, so for this card it is not sent. `PaymentUtils.nicknamePaymentMethodData` encodes that decision in one place.

---

### 3. Hyperswitch Vault — saved card (CVC re-collection)

📹 **Recording:** (attach)

This is the flow that changed most during review, and it now matches `hyperswitch-web` exactly.

**Vault call — note there is no `payment_method_token`:**

```http
PUT /v1/payment-method-sessions/{session_id}/update-saved-payment-method
Authorization: <sdk_authorization>
```

```json
{
  "payment_method_data": {
    "card": {
      "card_cvc": "…"
    }
  }
}
```

**Response → CVC token D:**

```json
{
  "associated_payment_methods": [
    {
      "payment_method_token": {
        "type": "payment_method_session_token",
        "data": "token_…"
      }
    }
  ],
  "card_cvc_token_storage": null
}
```

**Confirm — the original saved-card token is kept:**

```http
POST /payments/{id}/confirm
```

```json
{
  "payment_method": "card",
  "payment_token": "<A — from /payments/{id}/client>",
  "payment_method_data": {
    "card_token": {
      "card_cvc_token": "<D>"
    }
  }
}
```

D is a CVC token, not a payment method. Backend (`CardToken.card_cvc_token`) resolves it to the raw CVC during confirm and attaches it to the card. Using D as the top-level `payment_token` fails — it references no payment method.

An earlier revision of this PR fetched `GET /list-payment-methods`, matched each displayed card to a session token by `created|last4|expiry|network|subtype`, and sent that token on the update. That whole layer is gone: no extra round trip, no metadata join, no duplicate-card ambiguity, no loading state.

---

### 4. VGS — new card

📹 **Recording:** (attach)

VGS collects into its own inbound route and echoes aliases back. The adapter posts `card_number`, `expiration_date`, `card_cvc`, `card_holder`; the `/post` echo answers httpbin-style with those fields under `json`.

**Confirm — the aliased card rides in `vault_card` (backend ProxyCardData, routed through the external vault proxy):**

```http
POST /payments/{id}/confirm
```

```json
{
  "payment_method": "card",
  "payment_method_data": {
    "vault_card": {
      "card_number": "<alias>",
      "card_cvc": "<alias>",
      "card_exp_month": "12",
      "card_exp_year": "2030",
      "card_holder_name": "…",
      "nick_name": "My card"
    }
  }
}
```

VGS posts its expiry unmasked — `MMYY` for the default `##/##` mask, `MMYYYY` for a four-digit-year mask, `MM/YY`-style if a divider is configured. `splitVaultExpiry` handles all three and refuses anything else rather than guessing. A malformed echo fails loudly instead of being heuristically parsed.

Unlike the Hyperswitch path, a VGS card's `nick_name` sits beside the aliases inside `vault_card`, because `ProxyCardData` carries it.

---

### 5. VGS — saved card (CVC re-collection)

📹 **Recording:** (attach)

VGS never sends the SDK's token anywhere, so the displayed `payment_token` stands and only the CVC is aliased.

```http
POST /payments/{id}/confirm
```

```json
{
  "payment_method": "card",
  "payment_token": "<A>",
  "payment_method_data": {
    "vault_card_token": {
      "card_cvc": "<alias>"
    }
  }
}
```

The two saved-card representations stay strictly provider-specific: `card_token.card_cvc_token` is the self-hosted-vault contract, `vault_card_token.card_cvc` is the external-vault-proxy contract, and neither borrows the other's key. Tests assert both directions.

---

## Styling — how a provider field is made to look like ours

The hard constraint: the input is owned by the provider, so the SDK cannot read or write its value, cannot put a scan-card button over it, and cannot render a co-badged scheme dropdown that needs the PAN.

`VaultInput` draws everything except the value. The provider gets a two-key style object — `container` (height + full width) and `input` (height, width, zeroed padding, colour, fontFamily, and fontSize scaled by the merchant's `placeholderTextSizeAdjust` and the device `fontScale`). Everything else is ours: the animated floating label, the border box, the error colour, and whatever accessory the caller passes as `iconRight`.

Field state is reconstructed in RFF's terms. The provider reports empty / complete / valid / touched / brand and focus/blur; `VaultCardElement` tracks `{active, blurred}` per field and derives exactly what `CustomInput` would have shown:

- untouched until the first blur, or until a pay press marks everything touched;
- a field that hasn't reported yet is treated as empty, like a fresh RFF field;
- a problem only shows once the field is touched and is not the one being edited;
- a blur only counts once the field has actually held focus, so a stray mount-time blur can't mark an untouched field.

**Expiry parity.** `CardElement` shows an expiry error the moment a full past date is typed, without waiting for a blur. Only the Hyperswitch vault reports `expiryMonth`/`expiryYear` once both are typed, so `expiryFullyTyped` distinguishes `"12/23 fully typed"` from `"12/2 still typing"` without seeing the value. On VGS this stays false and the error waits for the blur, as it did before.

Focus advance is preserved: number → expiry → CVC as each field reports complete for the first time while focused.

Layout reuses `CardElement`'s exact geometry, including `splitCardFields` (fused single row vs. separate boxes) with per-corner radius and per-edge border widths so the fused row still reads as one control.

**Icons — the one visible provider difference.** VGS ships its own brand and CVC marks and draws them inside its field. Those are used as-is, so a VGS form carries a little of the provider's flavour while the box, label, layout and error copy stay ours. The adapter exposes them as on/off only (via `unstyled`), so the merchant's `cardBrandIcon` / `cvcIcon` config still decides whether a mark appears — just not which one. The Hyperswitch vault has no such set and keeps the SDK's own icons. A provider drawing its own icon reserves room as horizontal padding on the text, so only the vertical padding is zeroed there — zeroing all of it would run the digits under the icon. On the saved-card CVC field the box widens (100 → 128) to keep room for the digits next to the wider VGS mark.

**Not reachable, by design:** the co-badged scheme dropdown (needs every matched scheme) and the scan-card button (needs to write into the field) cannot exist over a secure field. The card-brand icon is still drawn from the reported brand.

---

## Validation and error handling

- The vault form is not an RFF form, so its own validity feeds `FormStatusEmitter` and the global confirm button (`effectiveFormValid = vaultValid && rffValid`). Billing, email and nickname stay gated by RFF; a press shows the errors of whichever half is short.
- A form that fails to mount drops its validity, so the pay button can't start a flow with no collector behind it.
- The unsupported-scheme message follows `CardElement`'s behaviour: the network field is never focused, so it only appears after a pay press.
- Provider validation refusals and errors coded as validation map to `NeedsInput` (fix a field); everything else maps to `Failed` with the customer-facing message and a code-only reason for logs.

---

## Files

### Added (8 + tests)

- `src/components/vault/VaultBindings.res`
- `src/components/vault/VaultCardElement.res`
- `src/components/vault/VaultCvcElement.res`
- `src/components/vault/VaultInput.res`
- `src/contexts/CardStrategyContext.res`
- `src/hooks/VaultCardSubmitHook.res`
- `src/types/AllApiDataTypes/VaultDetailsType.res`
- `src/utility/logics/VaultTokenNormalizer.res`
- `__tests__/VaultRegression-test.js`

### Modified

`ParentElement` / `DynamicFields` / `RequiredFields` (route CARD to the right renderer, thread `vaultFormId`), `TabElement` / `DynamicComponent` / `SavedPaymentSheet` (pay-button branches), `SavedPaymentMethod` (`SavedCardCvcInput` picks the CVC input; `CVVComponent` itself untouched so the express-checkout widget stays on the direct path), `NavigationRouter` (strategy), `PaymentUtils` (`readVaultingAction`, `isVaultedNewCard`, `nicknamePaymentMethodData`, confirm-body plumbing), `LoggerTypes` (`VAULT_TOKENIZE`).

### Dependencies

```text
@juspay-tech/react-native-hyperswitch-payment-methods  1.0.0
@juspay-tech/react-native-hyperswitch-vault            1.0.0
@vgs/collect-react-native                              ^1.2.0
```

`webpack.config.js` marks three optional peers of the payment-methods package (`@basis-theory/react-native-elements`, `@evervault/react-native`, `skyflow-react-native`) as `false`. The package requires them inside try/catch, so webpack only warned; this makes the absence explicit. No native code is added to any vault package.

---

## Testing

```text
yarn re:build                               pass
yarn re:check   (warnings-as-errors)        750/750
yarn build:web                              pass
npx jest __tests__/VaultRegression-test.js  20/20
git diff --check                            clean
```

`__tests__/VaultRegression-test.js` covers the normalisation boundary for all four vault shapes, the negative assertions (HS never sets `payment_token` or `vault_card_token`; VGS never sets `card_token`), nickname placement per representation, the direct path still sending clear `card_cvc`, one-press/one-tokenize/one-confirm, and the VGS icon contract.

### Sandbox verification (Hyperswitch saved card, real client-core path)

Driven through the compiled modules — `parseVaultDetails` → rendered `VaultCvcElement` → CVC typed into the secure field → `VaultBindings.tokenizeForm` → `VaultTokenNormalizer` → `generateSavedCardConfirmBody` → real confirm — with a fetch interceptor on every outbound request:

```text
PUT …/update-saved-payment-method → 200
  body keys: ['payment_method_data']
  'payment_method_token' in body: false
  no GET /list-payment-methods was made
```

```text
POST /payments/{id}/confirm → 200  status = succeeded  connector = checkout
  payment_token                                  = A   (=== client-listing token)
  payment_method_data.card_token.card_cvc_token = D
  payment_token === D                           : false
  card_cvc (clear) present                      : false
  vault_card_token present                      : false
```

Router: `x-hyperswitch-version: 2026.09.07.0`.

Backend behaviour confirmed by differential tests: a confirm with no CVC fails (`501 IR_00`); a fabricated `card_cvc_token` fails (`500 HE_00`); a reused D fails (`500 HE_00`) while a fresh one succeeds — i.e. the confirm genuinely dereferences and consumes the token.

---

## Known limitations / follow-ups

- CVC token is single-use. The backend deletes it on read, so a confirm that fails after consuming D cannot be retried with the same token — the customer must re-enter the CVC. `hyperswitch-web` has the same gap; worth handling in a follow-up.
- Backend version floor. `card_cvc_token` requires router ≥ `bb30ffa120` (2026-06-24). Older routers silently drop the field (`CardToken` is not `deny_unknown_fields`), so a self-hosted merchant on an older build would confirm without a CVC and get no error.
- The no-token update replaces `associated_payment_methods` with a single entry. Nothing in client-core reads that list afterwards, but a later token-carrying update or delete on the same session would fail.
- Vault library resolves its own base URL (`SANDBOX → app.hyperswitch.io/api`) rather than client-core's configured `baseUrl`. Both front the same cluster today, so it works — but it will matter for INTEG and self-hosted merchants. Raised with the library owners.
- Nickname is not sent for a Hyperswitch-vaulted new card (see flow 2). Needs either a PMS confirm field or a backend change to accept a `nick_name`-only `vault_card`.
- Card-only by design. A tokenize profile with zero renderable card fields drops the PM; `bank_debit` / `crypto` / `upi` are out of scope for this PR.

---

## Screen recordings

| # | Flow | Recording |
| --- | --- | --- |
| 1 | Direct card (`vaulting_action: skip`) | attach |
| 2 | Hyperswitch Vault — new card | attach |
| 3 | Hyperswitch Vault — saved card CVC | attach |
| 4 | VGS — new card | attach |
| 5 | VGS — saved card CVC | attach |

---